### PR TITLE
fix: Add Stripe environment variables to API deployment

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -59,4 +59,8 @@ jobs:
             "Supabase__JwtSecret=${{ secrets.SUPABASE_JWT_SECRET }}" \
             "Supabase__JwtIssuer=${{ secrets.SUPABASE_JWT_ISSUER }}" \
             "FrontendUrl=${{ secrets.WEB_URL }}" \
-            "Sentry__Dsn=${{ secrets.SENTRY_DSN }}"
+            "Sentry__Dsn=${{ secrets.SENTRY_DSN }}" \
+            "Stripe__SecretKey=${{ secrets.STRIPE_SECRET_KEY }}" \
+            "Stripe__PublishableKey=${{ secrets.STRIPE_PUBLISHABLE_KEY }}" \
+            "Stripe__WebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }}" \
+            "Stripe__PricePlanId=${{ secrets.STRIPE_PRICE_PLAN_ID }}"


### PR DESCRIPTION
## Summary

Resolves API startup failure after PR #31 merge by adding required Stripe environment variables to the deployment workflow.

## Problem

After merging PR #31, the API service fails to start with:
```
fail: RadioWash.Api.Services.Implementations.StripeHealthCheckService[0]
      Stripe:SecretKey is not configured
fail: Program[0]
      Stripe configuration validation failed - application will not start
```

## Root Cause

PR #31 introduced production-ready Stripe configuration validation that prevents the application from starting if Stripe environment variables are not properly configured. The deployment workflow was missing these required environment variables.

## Solution

Added the following Stripe environment variables to the Azure App Service deployment:

- `Stripe__SecretKey`: Required for server-side payment processing
- `Stripe__PublishableKey`: Required for client-side Stripe integration  
- `Stripe__WebhookSecret`: Required for webhook signature validation
- `Stripe__PricePlanId`: Required for subscription plan creation

## Impact

✅ **Resolves**: API 503 Service Unavailable errors  
✅ **Enables**: Subscription system functionality from PR #31  
✅ **Maintains**: Production security validation  
✅ **Restores**: Dashboard functionality  

🤖 Generated with [Claude Code](https://claude.ai/code)