### PR TITLE
fix: Prevent hydration errors from date/time locale mismatches

### DIFF
--- a/web/src/app/components/SpotifyConnectionStatus.tsx
+++ b/web/src/app/components/SpotifyConnectionStatus.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { createClient } from '../lib/supabase/client';
+import { ClientDate } from '@/components/ui/ClientDate';
 
 const API_BASE_URL =
   (process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:5159') + '/api';
@@ -155,13 +156,19 @@ export function SpotifyConnectionStatus({
               {status.connected ? 'Spotify Connected' : 'Spotify Not Connected'}
             </h3>
             <p className="text-sm text-muted-foreground">
-              {status.connected
-                ? `Connected ${
-                    status.connectedAt
-                      ? new Date(status.connectedAt).toLocaleDateString()
-                      : ''
-                  }`
-                : 'Connect your Spotify account to access playlists'}
+              {status.connected ? (
+                <>
+                  Connected{' '}
+                  {status.connectedAt && (
+                    <ClientDate
+                      date={status.connectedAt}
+                      format="toLocaleDateString"
+                    />
+                  )}
+                </>
+              ) : (
+                'Connect your Spotify account to access playlists'
+              )}
             </p>
           </div>
         </div>
@@ -188,7 +195,7 @@ export function SpotifyConnectionStatus({
       {status.connected && status.lastRefreshAt && (
         <div className="mt-4 pt-4">
           <p className="text-xs text-muted-foreground">
-            Last refreshed: {new Date(status.lastRefreshAt).toLocaleString()}
+            Last refreshed: <ClientDate date={status.lastRefreshAt} />
           </p>
         </div>
       )}

--- a/web/src/app/components/ui/ClientDate.tsx
+++ b/web/src/app/components/ui/ClientDate.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface ClientDateProps {
+  date: string | Date;
+  format?: 'toLocaleString' | 'toLocaleDateString';
+  fallback?: string;
+  className?: string;
+}
+
+/**
+ * A component that safely renders dates on the client side only.
+ * This prevents hydration mismatches caused by timezone/locale differences
+ * between server and client rendering.
+ */
+export function ClientDate({
+  date,
+  format = 'toLocaleString',
+  fallback = '',
+  className,
+}: ClientDateProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return fallback ? <span className={className}>{fallback}</span> : null;
+  }
+
+  const d = new Date(date);
+  const formatted =
+    format === 'toLocaleDateString'
+      ? d.toLocaleDateString()
+      : d.toLocaleString();
+
+  return <span className={className}>{formatted}</span>;
+}

--- a/web/src/app/components/ux/JobCard.tsx
+++ b/web/src/app/components/ux/JobCard.tsx
@@ -4,6 +4,7 @@ import { usePlaylistProgressRealtime } from '@/hooks/usePlaylistProgressRealtime
 import { useAuthToken } from '@/hooks/useAuthToken';
 import { logger } from '@/lib/logger';
 import { useEffect, useRef } from 'react';
+import { ClientDate } from '@/components/ui/ClientDate';
 
 export function JobCard({ job }: { job: Job }) {
   const { authToken } = useAuthToken();
@@ -231,7 +232,7 @@ export function JobCard({ job }: { job: Job }) {
         </div>
       )}
       <p className="text-xs text-muted-foreground mt-2 text-right">
-        Updated: {new Date(job.updatedAt).toLocaleString()}
+        Updated: <ClientDate date={job.updatedAt} />
       </p>
     </Link>
   );


### PR DESCRIPTION
## Summary
- Add `ClientDate` component that defers date rendering to client-side only
- Update `JobCard` and `SpotifyConnectionStatus` to use the new component
- Prevents hydration mismatches caused by timezone/locale differences between server (UTC) and client browser

## Problem
Users on iOS (specifically Chrome Mobile iOS) were experiencing hydration errors on `/dashboard`. The root cause was `toLocaleString()` and `toLocaleDateString()` producing different outputs on server vs client due to timezone differences.

## Solution
Created a reusable `ClientDate` component that:
1. Renders nothing (or a fallback) during SSR
2. Only renders the formatted date after client-side hydration completes
3. Uses `useEffect` to detect when the component has mounted on the client

## Files Changed
- `web/src/app/components/ui/ClientDate.tsx` - New component
- `web/src/app/components/ux/JobCard.tsx` - Updated to use ClientDate
- `web/src/app/components/SpotifyConnectionStatus.tsx` - Updated to use ClientDate

## Test plan
- [ ] Verify no hydration errors in browser console on dashboard page
- [ ] Verify dates render correctly after page load
- [ ] Test on mobile Safari/Chrome to confirm fix

Generated with Claude Code