### PR TITLE
fix: Redirect authenticated users from /auth in middleware

### DIFF
--- a/web/src/app/lib/supabase/middleware.ts
+++ b/web/src/app/lib/supabase/middleware.ts
@@ -34,17 +34,12 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
+  // Redirect authenticated users away from auth page to dashboard
+  // This prevents timing issues where the auth page might not detect
+  // a freshly refreshed session, causing users to see the login form
+  if (user && request.nextUrl.pathname === '/auth') {
+    return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+
   return response;
 }
-
-export const config = {
-  matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     */
-    '/((?!_next/static|_next/image|favicon.ico).*)',
-  ],
-};

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -4,3 +4,15 @@ import { type NextRequest } from 'next/server';
 export async function middleware(request: NextRequest) {
   return updateSession(request);
 }
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!_next/static|_next/image|favicon.ico).*)',
+  ],
+};


### PR DESCRIPTION
## Summary
Fixes the "double click to sign in" bug where returning users with expired JWTs had to click the "Connect with Spotify" button twice before reaching the dashboard.

## Problem
Users with expired JWT tokens (but valid refresh tokens) would experience:
1. Click "Connect with Spotify" → redirected to homepage
2. Click button again → successfully reach dashboard

This happened due to a timing issue between:
- Middleware refreshing the session and setting new cookies on the response
- Auth page creating a new Supabase client and reading from the request (which still had old cookies)

## Solution
The middleware now redirects authenticated users directly from `/auth` to `/dashboard` after successfully refreshing their session. This happens in the same request cycle, eliminating the timing issue.

### Changes Made
1. **`web/src/app/lib/supabase/middleware.ts`**
   - Added redirect for authenticated users accessing `/auth`
   - Removed duplicate `config.matcher` export

2. **`web/src/middleware.ts`**
   - Added proper `config.matcher` export (Next.js expects it here)

## Benefits
- Eliminates the "double click" experience for returning users
- More efficient - authenticated users never render the auth page
- Better UX - smoother transition for users with expired sessions

## Test Plan
- [x] Build succeeds without TypeScript errors
- [ ] Manual test: Wait for JWT to expire (or set short expiry), click "Connect with Spotify", verify immediate redirect to dashboard
- [ ] Verify new users can still authenticate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)