### PR TITLE
fix(web): remove leaked Sentry auth token from client bundle and image layers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,14 @@ NEXT_PUBLIC_PLAUSIBLE_DOMAIN=your_domain.com
 # Sentry Configuration
 # ===================
 
-NEXT_PUBLIC_SENTRY_AUTH_TOKEN=your_sentry_auth_token
+# Build-time only: used by @sentry/nextjs to upload source maps during `pnpm build`.
+# Must NOT be prefixed with NEXT_PUBLIC_ (that would inline the token into the client bundle).
+SENTRY_AUTH_TOKEN=your_sentry_auth_token
+
+# Public DSN (safe to ship in the client bundle).
 NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn
+
+# Server-side DSN (used by sentry.server.config.js in the Node.js runtime).
 SENTRY_DSN=your_sentry_dsn
 
 # ===================

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -50,9 +50,10 @@ jobs:
             NEXT_PUBLIC_SUPABASE_URL=${{ secrets.SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
             NEXT_PUBLIC_WEB_URL=${{ secrets.WEB_URL }}
-            NEXT_PUBLIC_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+          secrets: |
+            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -67,7 +68,7 @@ jobs:
                 --name ${{ env.APP_NAME }} \
                 --resource-group ${{ env.RESOURCE_GROUP }} \
                 --image ${{ secrets.ACR_LOGIN_SERVER }}/radiowash-web:${{ github.sha }} \
-                --set-env-vars NEXT_PUBLIC_SERVICE_AVAILABLE=${{ secrets.NEXT_PUBLIC_SERVICE_AVAILABLE }} NEXT_PUBLIC_API_URL=${{ secrets.API_URL }} NEXT_PUBLIC_SUPABASE_URL=${{ secrets.SUPABASE_URL }} NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }} NEXT_PUBLIC_WEB_URL=${{ secrets.WEB_URL }} NEXT_PUBLIC_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }} SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+                --set-env-vars NEXT_PUBLIC_SERVICE_AVAILABLE=${{ secrets.NEXT_PUBLIC_SERVICE_AVAILABLE }} NEXT_PUBLIC_API_URL=${{ secrets.API_URL }} NEXT_PUBLIC_SUPABASE_URL=${{ secrets.SUPABASE_URL }} NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }} NEXT_PUBLIC_WEB_URL=${{ secrets.WEB_URL }} NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }} SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             else
               echo "Creating new container app..."
               az containerapp create \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -28,21 +28,24 @@ ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG NEXT_PUBLIC_WEB_URL
 ARG NEXT_PUBLIC_SERVICE_AVAILABLE
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG SENTRY_DSN
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV NEXT_PUBLIC_WEB_URL=$NEXT_PUBLIC_WEB_URL
 ENV NEXT_PUBLIC_SERVICE_AVAILABLE=$NEXT_PUBLIC_SERVICE_AVAILABLE
-ENV NEXT_PUBLIC_SENTRY_DSN=https://8f721e77caccd1f5e3dacd84af24c4a7@o4510213599330305.ingest.us.sentry.io/4510228229980160
-ENV NEXT_PUBLIC_SENTRY_AUTH_TOKEN=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
-ENV SENTRY_DSN=https://8f721e77caccd1f5e3dacd84af24c4a7@o4510213599330305.ingest.us.sentry.io/4510228229980160
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ENV SENTRY_DSN=$SENTRY_DSN
 
 # Remove dotnet plugin for web build
 RUN apk update && apk add jq
 RUN jq 'del(.plugins[] | select(.plugin == "@nx-dotnet/core"))' nx.json > nx-web.json && mv nx-web.json nx.json
 
-# Build the web application using NX with production config
-RUN corepack enable pnpm && pnpm nx build web --configuration=production
+# SENTRY_AUTH_TOKEN is mounted as a BuildKit secret, exposed only for the duration
+# of the build command, and never written to an image layer.
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+    corepack enable pnpm && pnpm nx build web --configuration=production
 
 # Production image, copy all the files and run next
 FROM base AS runner


### PR DESCRIPTION
## Summary

The previous build pipeline injected the Sentry auth token as `NEXT_PUBLIC_SENTRY_AUTH_TOKEN`, which caused Next.js to inline it into the client JavaScript bundle served to browsers. It was also persisted in Docker image layers via `ENV` and set as a runtime environment variable on the Azure Container App. The leaked token has already been revoked in Sentry and replaced.

This PR applies the structural fixes that prevent the same mistake from recurring.

- **`web/Dockerfile`** — Add missing `ARG` declarations for the Sentry vars, drop the `NEXT_PUBLIC_` prefix on the auth token entirely, and mount it as a BuildKit secret on the `pnpm build` step so the value is available to `@sentry/nextjs` for source-map upload but is never written to an image layer.
- **`.github/workflows/web-deploy.yml`** — Inject the token via `docker/build-push-action`'s `secrets:` input rather than as a build-arg, and remove it from the Container App runtime environment variables. The runtime has no need for an upload-only credential.
- **`.env.example`** — Rename `NEXT_PUBLIC_SENTRY_AUTH_TOKEN` to `SENTRY_AUTH_TOKEN` with an inline note explaining why the `NEXT_PUBLIC_` prefix must not be used on build-time-only secrets.

Runtime Sentry SDK initialization continues to use `NEXT_PUBLIC_SENTRY_DSN` (client) and `SENTRY_DSN` (server) — the DSN is a public identifier and is safe to ship.

## Context

Part of the subscription/payment production-readiness audit. The leak was surfaced by the devils-advocate review of the audit plan. This is Task 0 of the plan at `~/.claude/plans/audit-the-current-workflow-harmonic-platypus.md`.

Historical note: the revoked token remains visible in git history across earlier commits. That is treated as permanent exposure and is documented in the forthcoming subscription ops runbook (Task 9) so the team knows not to reuse it from old branches or local copies.

## Test plan

- [ ] CI build succeeds against the new `secrets:` input.
- [ ] Source-map upload to Sentry still completes during `pnpm nx build web --configuration=production`.
- [ ] `docker history <image> --no-trunc | grep -i sentry` shows only the DSN in image metadata after deploy — no auth token in any layer.
- [ ] `grep -r "NEXT_PUBLIC_SENTRY_AUTH\|sntrys_"` returns zero matches in the working tree.
- [ ] Staging Container App still reports errors to Sentry after the deploy (DSN injection path works).
- [ ] Confirm the GitHub Actions secret `SENTRY_AUTH_TOKEN` holds the new (post-rotation) token value before merging to main.