### PR TITLE
fix(api): enforce subscription expiry and re-enable configs on reactivation

### DIFF
--- a/api.Tests/Unit/Services/PlaylistSyncServiceTests.cs
+++ b/api.Tests/Unit/Services/PlaylistSyncServiceTests.cs
@@ -65,7 +65,7 @@ public class PlaylistSyncServiceTests
     _mockUnitOfWork.Setup(x => x.SyncConfigs.UpdateNextScheduledSyncAsync(It.IsAny<int>(), It.IsAny<DateTime>()))
         .Returns(Task.CompletedTask);
 
-    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>()))
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()))
         .Returns(Task.CompletedTask);
 
     _mockUnitOfWork.Setup(x => x.TrackMappings.AddAsync(It.IsAny<TrackMapping>()))
@@ -89,7 +89,7 @@ public class PlaylistSyncServiceTests
     Assert.False(result.Success);
     Assert.Contains("subscription", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
 
-    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(config.Id), Times.Once);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(config.Id, AutoDisableReason.SubscriptionInactive), Times.Once);
   }
 
   [Fact]
@@ -318,7 +318,7 @@ public class PlaylistSyncServiceTests
 
     // Assert
     Assert.True(result);
-    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(configId), Times.Once);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(configId, null), Times.Once);
   }
 
   [Fact]

--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -287,11 +287,11 @@ public class SubscriptionServiceTests
 
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
         .ReturnsAsync(subscription);
-    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetByUserIdAsync(userId))
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
         .ReturnsAsync(syncConfigs);
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => s);
-    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>()))
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()))
         .Returns(Task.CompletedTask);
 
     // Act
@@ -302,7 +302,129 @@ public class SubscriptionServiceTests
     Assert.Equal(SubscriptionStatus.Canceled, result.Status);
     Assert.NotNull(result.CanceledAt);
 
-    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(1), Times.Once);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(1, AutoDisableReason.SubscriptionInactive), Times.Once);
+  }
+
+  [Fact]
+  public async Task ValidateSubscriptionsAsync_WithSubscriptionPastGraceWindow_TransitionsToCanceledAndDisablesEnabledConfigs()
+  {
+    // Arrange: subscription expired 48h ago (past the 24h grace window)
+    var userId = 42;
+    var expired = CreateUserSubscription(userId);
+    expired.CurrentPeriodEnd = DateTime.UtcNow.AddHours(-48);
+
+    var enabledConfig = new PlaylistSyncConfig { Id = 7, UserId = userId, IsActive = true };
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetExpiredActiveSubscriptionsAsync(It.IsAny<DateTime>()))
+        .ReturnsAsync(new[] { expired });
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
+        .ReturnsAsync(new[] { enabledConfig });
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()))
+        .Returns(Task.CompletedTask);
+
+    // Act
+    await _subscriptionService.ValidateSubscriptionsAsync();
+
+    // Assert: subscription transitioned to Canceled, CanceledAt stamped, config tagged and disabled
+    Assert.Equal(SubscriptionStatus.Canceled, expired.Status);
+    Assert.NotNull(expired.CanceledAt);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(expired), Times.Once);
+    _mockUnitOfWork.Verify(
+        x => x.SyncConfigs.DisableConfigAsync(enabledConfig.Id, AutoDisableReason.SubscriptionInactive),
+        Times.Once);
+  }
+
+  [Fact]
+  public async Task ValidateSubscriptionsAsync_WithSubscriptionInsideGraceWindow_LeavesStateUnchanged()
+  {
+    // Arrange: the repository filter (GetExpiredActiveSubscriptionsAsync) is what enforces the
+    // grace window — verify the service passes the correct cutoff (UtcNow - 24h). If nothing
+    // matches the cutoff, nothing is updated.
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetExpiredActiveSubscriptionsAsync(It.IsAny<DateTime>()))
+        .ReturnsAsync(Array.Empty<UserSubscription>());
+
+    // Act
+    await _subscriptionService.ValidateSubscriptionsAsync();
+
+    // Assert: no writes happened, and the cutoff was at least 23 hours in the past (allows for
+    // clock skew between capture and the assertion)
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()), Times.Never);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()), Times.Never);
+    _mockUnitOfWork.Verify(
+        x => x.UserSubscriptions.GetExpiredActiveSubscriptionsAsync(It.Is<DateTime>(d => d < DateTime.UtcNow.AddHours(-23))),
+        Times.Once);
+  }
+
+  [Fact]
+  public async Task ValidateSubscriptionsAsync_WithOneFailingSubscription_ContinuesBatch()
+  {
+    // Arrange: two expired subscriptions; the first UpdateAsync throws
+    var failing = CreateUserSubscription(1);
+    failing.Id = 1;
+    failing.CurrentPeriodEnd = DateTime.UtcNow.AddHours(-48);
+
+    var succeeding = CreateUserSubscription(2);
+    succeeding.Id = 2;
+    succeeding.CurrentPeriodEnd = DateTime.UtcNow.AddHours(-48);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetExpiredActiveSubscriptionsAsync(It.IsAny<DateTime>()))
+        .ReturnsAsync(new[] { failing, succeeding });
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(failing))
+        .ThrowsAsync(new InvalidOperationException("db transient"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(succeeding))
+        .ReturnsAsync(succeeding);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(It.IsAny<int>()))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    await _subscriptionService.ValidateSubscriptionsAsync();
+
+    // Assert: both updates attempted; the second succeeded
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(failing), Times.Once);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(succeeding), Times.Once);
+    Assert.Equal(SubscriptionStatus.Canceled, succeeding.Status);
+  }
+
+  [Fact]
+  public async Task ReactivateSyncConfigsAsync_EnablesOnlyAutoDisabledConfigs()
+  {
+    // Arrange
+    var userId = 5;
+    var autoDisabled = new[]
+    {
+        new PlaylistSyncConfig { Id = 10, UserId = userId, IsActive = false, AutoDisabledReason = AutoDisableReason.SubscriptionInactive },
+        new PlaylistSyncConfig { Id = 11, UserId = userId, IsActive = false, AutoDisabledReason = AutoDisableReason.SubscriptionInactive },
+    };
+
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
+        .ReturnsAsync(autoDisabled);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.EnableConfigAsync(It.IsAny<int>()))
+        .Returns(Task.CompletedTask);
+
+    // Act
+    await _subscriptionService.ReactivateSyncConfigsAsync(userId);
+
+    // Assert
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.EnableConfigAsync(10), Times.Once);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.EnableConfigAsync(11), Times.Once);
+  }
+
+  [Fact]
+  public async Task ReactivateSyncConfigsAsync_WithNoAutoDisabledConfigs_IsNoop()
+  {
+    // Arrange
+    var userId = 6;
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    await _subscriptionService.ReactivateSyncConfigsAsync(userId);
+
+    // Assert
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.EnableConfigAsync(It.IsAny<int>()), Times.Never);
   }
 
   private static UserSubscription CreateUserSubscription(int userId)

--- a/api/Infrastructure/Repositories/IPlaylistSyncConfigRepository.cs
+++ b/api/Infrastructure/Repositories/IPlaylistSyncConfigRepository.cs
@@ -7,12 +7,15 @@ public interface IPlaylistSyncConfigRepository
   Task<PlaylistSyncConfig?> GetByIdAsync(int configId);
   Task<PlaylistSyncConfig?> GetByJobIdAsync(int jobId);
   Task<IEnumerable<PlaylistSyncConfig>> GetByUserIdAsync(int userId);
+  Task<IEnumerable<PlaylistSyncConfig>> GetEnabledByUserIdAsync(int userId);
+  Task<IEnumerable<PlaylistSyncConfig>> GetAutoDisabledByUserIdAsync(int userId, string reason);
   Task<IEnumerable<PlaylistSyncConfig>> GetDueForSyncAsync(DateTime currentTime);
   Task<IEnumerable<PlaylistSyncConfig>> GetActiveConfigsAsync();
   Task<PlaylistSyncConfig> CreateAsync(PlaylistSyncConfig config);
   Task<PlaylistSyncConfig> UpdateAsync(PlaylistSyncConfig config);
   Task UpdateLastSyncAsync(int configId, DateTime syncTime, string status, string? error = null);
   Task UpdateNextScheduledSyncAsync(int configId, DateTime nextSync);
-  Task DisableConfigAsync(int configId);
+  Task DisableConfigAsync(int configId, string? autoDisabledReason = null);
+  Task EnableConfigAsync(int configId);
   Task SaveChangesAsync();
 }

--- a/api/Infrastructure/Repositories/IUserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/IUserSubscriptionRepository.cs
@@ -13,6 +13,7 @@ public interface IUserSubscriptionRepository
   Task<IEnumerable<UserSubscription>> GetActiveSubscriptionsWithDetailsAsync();
   Task<IEnumerable<UserSubscription>> GetExpiringSubscriptionsAsync(DateTime before);
   Task<IEnumerable<UserSubscription>> GetExpiringSubscriptionsWithDetailsAsync(DateTime before);
+  Task<IEnumerable<UserSubscription>> GetExpiredActiveSubscriptionsAsync(DateTime cutoff);
   Task<UserSubscription> CreateAsync(UserSubscription subscription);
   Task<UserSubscription> UpdateAsync(UserSubscription subscription);
   Task<bool> HasActiveSubscriptionAsync(int userId);

--- a/api/Infrastructure/Repositories/PlaylistSyncConfigRepository.cs
+++ b/api/Infrastructure/Repositories/PlaylistSyncConfigRepository.cs
@@ -38,6 +38,24 @@ public class PlaylistSyncConfigRepository : IPlaylistSyncConfigRepository
         .ToListAsync();
   }
 
+  public async Task<IEnumerable<PlaylistSyncConfig>> GetEnabledByUserIdAsync(int userId)
+  {
+    return await _dbContext.PlaylistSyncConfigs
+        .Include(psc => psc.OriginalJob)
+        .Where(psc => psc.UserId == userId && psc.IsActive)
+        .OrderByDescending(psc => psc.CreatedAt)
+        .ToListAsync();
+  }
+
+  public async Task<IEnumerable<PlaylistSyncConfig>> GetAutoDisabledByUserIdAsync(int userId, string reason)
+  {
+    return await _dbContext.PlaylistSyncConfigs
+        .Where(psc => psc.UserId == userId
+                      && !psc.IsActive
+                      && psc.AutoDisabledReason == reason)
+        .ToListAsync();
+  }
+
   public async Task<IEnumerable<PlaylistSyncConfig>> GetDueForSyncAsync(DateTime currentTime)
   {
     return await _dbContext.PlaylistSyncConfigs
@@ -97,12 +115,25 @@ public class PlaylistSyncConfigRepository : IPlaylistSyncConfigRepository
     }
   }
 
-  public async Task DisableConfigAsync(int configId)
+  public async Task DisableConfigAsync(int configId, string? autoDisabledReason = null)
   {
     var config = await _dbContext.PlaylistSyncConfigs.FindAsync(configId);
     if (config != null)
     {
       config.IsActive = false;
+      config.AutoDisabledReason = autoDisabledReason;
+      config.UpdatedAt = DateTime.UtcNow;
+      await _dbContext.SaveChangesAsync();
+    }
+  }
+
+  public async Task EnableConfigAsync(int configId)
+  {
+    var config = await _dbContext.PlaylistSyncConfigs.FindAsync(configId);
+    if (config != null)
+    {
+      config.IsActive = true;
+      config.AutoDisabledReason = null;
       config.UpdatedAt = DateTime.UtcNow;
       await _dbContext.SaveChangesAsync();
     }

--- a/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
@@ -89,6 +89,19 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
         .ToListAsync();
   }
 
+  // Returns Active subscriptions whose CurrentPeriodEnd is strictly before the given cutoff —
+  // callers pass UtcNow - graceWindow to avoid racing with Stripe's renewal webhook which may
+  // arrive minutes after CurrentPeriodEnd. Subscriptions with a null CurrentPeriodEnd are
+  // skipped because they represent an incomplete state Stripe hasn't finalized.
+  public async Task<IEnumerable<UserSubscription>> GetExpiredActiveSubscriptionsAsync(DateTime cutoff)
+  {
+    return await _dbContext.UserSubscriptions
+        .Where(us => us.Status == SubscriptionStatus.Active &&
+                    us.CurrentPeriodEnd.HasValue &&
+                    us.CurrentPeriodEnd.Value < cutoff)
+        .ToListAsync();
+  }
+
   public async Task<UserSubscription> CreateAsync(UserSubscription subscription)
   {
     _dbContext.UserSubscriptions.Add(subscription);

--- a/api/Migrations/20260418184350_AddAutoDisabledReasonToSyncConfig.Designer.cs
+++ b/api/Migrations/20260418184350_AddAutoDisabledReasonToSyncConfig.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RadioWash.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using RadioWash.Api.Infrastructure.Data;
 namespace RadioWash.Api.Migrations
 {
     [DbContext(typeof(RadioWashDbContext))]
-    partial class RadioWashDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418184350_AddAutoDisabledReasonToSyncConfig")]
+    partial class AddAutoDisabledReasonToSyncConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260418184350_AddAutoDisabledReasonToSyncConfig.cs
+++ b/api/Migrations/20260418184350_AddAutoDisabledReasonToSyncConfig.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RadioWash.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutoDisabledReasonToSyncConfig : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AutoDisabledReason",
+                table: "PlaylistSyncConfigs",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AutoDisabledReason",
+                table: "PlaylistSyncConfigs");
+        }
+    }
+}

--- a/api/Models/Domain/PlaylistSyncConfig.cs
+++ b/api/Models/Domain/PlaylistSyncConfig.cs
@@ -15,6 +15,13 @@ public static class SyncStatus
   public const string Failed = "failed";
 }
 
+public static class AutoDisableReason
+{
+  // Set when a subscription transitions away from Active (canceled, expired, past_due).
+  // Configs with this reason are eligible to be re-enabled if the subscription returns to Active.
+  public const string SubscriptionInactive = "subscription_inactive";
+}
+
 public class PlaylistSyncConfig
 {
   public int Id { get; set; }
@@ -29,6 +36,7 @@ public class PlaylistSyncConfig
   public string? LastSyncError { get; set; }
   public DateTime? NextScheduledSync { get; set; }
   public string? SyncStats { get; set; } // JSON stats
+  public string? AutoDisabledReason { get; set; }
   public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
   public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -276,6 +276,7 @@ if (!builder.Environment.IsEnvironment("Testing") && !builder.Environment.IsEnvi
 
 // Background services
 builder.Services.AddHostedService<WebhookRetryBackgroundService>();
+builder.Services.AddHostedService<SubscriptionExpiryBackgroundService>();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();

--- a/api/Services/BackgroundServices/SubscriptionExpiryBackgroundService.cs
+++ b/api/Services/BackgroundServices/SubscriptionExpiryBackgroundService.cs
@@ -1,0 +1,54 @@
+using RadioWash.Api.Services.Interfaces;
+
+namespace RadioWash.Api.Services.BackgroundServices;
+
+public class SubscriptionExpiryBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<SubscriptionExpiryBackgroundService> _logger;
+    private readonly TimeSpan _processingInterval = TimeSpan.FromHours(1);
+
+    public SubscriptionExpiryBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<SubscriptionExpiryBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("SubscriptionExpiryBackgroundService started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ValidateOnceAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error validating subscription expiry: {ErrorMessage}", ex.Message);
+            }
+
+            try
+            {
+                await Task.Delay(_processingInterval, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                // Graceful shutdown
+                break;
+            }
+        }
+
+        _logger.LogInformation("SubscriptionExpiryBackgroundService stopped");
+    }
+
+    private async Task ValidateOnceAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var subscriptionService = scope.ServiceProvider.GetRequiredService<ISubscriptionService>();
+        await subscriptionService.ValidateSubscriptionsAsync();
+    }
+}

--- a/api/Services/Implementations/PlaylistSyncService.cs
+++ b/api/Services/Implementations/PlaylistSyncService.cs
@@ -61,7 +61,7 @@ public class PlaylistSyncService : IPlaylistSyncService
             {
                 _logger.LogWarning("User {UserId} does not have active subscription, disabling sync config {ConfigId}",
                     config.UserId, config.Id);
-                await _unitOfWork.SyncConfigs.DisableConfigAsync(config.Id);
+                await _unitOfWork.SyncConfigs.DisableConfigAsync(config.Id, AutoDisableReason.SubscriptionInactive);
 
                 throw new InvalidOperationException("User does not have an active subscription");
             }

--- a/api/Services/Implementations/StripeWebhookProcessor.cs
+++ b/api/Services/Implementations/StripeWebhookProcessor.cs
@@ -114,7 +114,20 @@ public class StripeWebhookProcessor : IWebhookProcessor
         var subscription = stripeEvent.Data.Object as Stripe.Subscription;
         if (subscription == null) return;
 
+        var existing = await _dbContext.UserSubscriptions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(us => us.StripeSubscriptionId == subscription.Id);
+        var previousStatus = existing?.Status;
+        var userId = existing?.UserId;
+
         await _subscriptionService.UpdateSubscriptionStatusAsync(subscription.Id, subscription.Status);
+
+        if (userId.HasValue
+            && subscription.Status == SubscriptionStatus.Active
+            && IsInactiveStatus(previousStatus))
+        {
+            await _subscriptionService.ReactivateSyncConfigsAsync(userId.Value);
+        }
 
         // Get period dates from subscription items (v49 compatibility)
         DateTime? currentPeriodStart = null;
@@ -358,11 +371,22 @@ public class StripeWebhookProcessor : IWebhookProcessor
 
             if (!string.IsNullOrEmpty(subscriptionId))
             {
-                _logger.LogInformation("Payment succeeded for subscription {SubscriptionId}, invoice {InvoiceId}", 
+                _logger.LogInformation("Payment succeeded for subscription {SubscriptionId}, invoice {InvoiceId}",
                     subscriptionId, invoice.Id);
-                
-                // Update subscription status to active (in case it was incomplete)
+
+                var existing = await _dbContext.UserSubscriptions
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(us => us.StripeSubscriptionId == subscriptionId);
+                var previousStatus = existing?.Status;
+                var userId = existing?.UserId;
+
+                // Update subscription status to active (in case it was incomplete or past_due)
                 await _subscriptionService.UpdateSubscriptionStatusAsync(subscriptionId, SubscriptionStatus.Active);
+
+                if (userId.HasValue && IsInactiveStatus(previousStatus))
+                {
+                    await _subscriptionService.ReactivateSyncConfigsAsync(userId.Value);
+                }
             }
             else
             {
@@ -376,5 +400,12 @@ public class StripeWebhookProcessor : IWebhookProcessor
         }
 
         await Task.CompletedTask;
+    }
+
+    private static bool IsInactiveStatus(string? status)
+    {
+        return status == SubscriptionStatus.PastDue
+            || status == SubscriptionStatus.Canceled
+            || status == SubscriptionStatus.Incomplete;
     }
 }

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -6,6 +6,10 @@ namespace RadioWash.Api.Services.Implementations;
 
 public class SubscriptionService : ISubscriptionService
 {
+  // Renewal webhooks from Stripe can land minutes after CurrentPeriodEnd, so the expiry job
+  // only transitions subscriptions that are past the end of their period by this window.
+  private static readonly TimeSpan ExpiryGraceWindow = TimeSpan.FromHours(24);
+
   private readonly IUnitOfWork _unitOfWork;
   private readonly ILogger<SubscriptionService> _logger;
 
@@ -100,14 +104,18 @@ public class SubscriptionService : ISubscriptionService
     subscription.Status = SubscriptionStatus.Canceled;
     subscription.CanceledAt = DateTime.UtcNow;
 
-    // Disable all sync configs for this user
-    var syncConfigs = await _unitOfWork.SyncConfigs.GetByUserIdAsync(userId);
-    foreach (var config in syncConfigs)
-    {
-      await _unitOfWork.SyncConfigs.DisableConfigAsync(config.Id);
-    }
+    await DisableSyncConfigsForUserAsync(userId);
 
     return await _unitOfWork.UserSubscriptions.UpdateAsync(subscription);
+  }
+
+  private async Task DisableSyncConfigsForUserAsync(int userId)
+  {
+    var enabledConfigs = await _unitOfWork.SyncConfigs.GetEnabledByUserIdAsync(userId);
+    foreach (var config in enabledConfigs)
+    {
+      await _unitOfWork.SyncConfigs.DisableConfigAsync(config.Id, AutoDisableReason.SubscriptionInactive);
+    }
   }
 
   public async Task<IEnumerable<SubscriptionPlan>> GetAvailablePlansAsync()
@@ -127,24 +135,58 @@ public class SubscriptionService : ISubscriptionService
 
   public async Task ValidateSubscriptionsAsync()
   {
-    _logger.LogInformation("Starting subscription validation");
+    var cutoff = DateTime.UtcNow - ExpiryGraceWindow;
+    var expiredSubscriptions = await _unitOfWork.UserSubscriptions.GetExpiredActiveSubscriptionsAsync(cutoff);
+    var expiredList = expiredSubscriptions.ToList();
 
-    var expiredSubscriptions = await _unitOfWork.UserSubscriptions.GetExpiringSubscriptionsAsync(DateTime.UtcNow);
-
-    foreach (var subscription in expiredSubscriptions)
+    if (expiredList.Count == 0)
     {
-      _logger.LogWarning("Subscription {SubscriptionId} for user {UserId} has expired",
-          subscription.Id, subscription.UserId);
-
-      // Disable sync configs for expired subscriptions
-      var syncConfigs = await _unitOfWork.SyncConfigs.GetByUserIdAsync(subscription.UserId);
-      foreach (var config in syncConfigs)
-      {
-        await _unitOfWork.SyncConfigs.DisableConfigAsync(config.Id);
-      }
+      return;
     }
 
-    _logger.LogInformation("Subscription validation completed. {ExpiredCount} subscriptions processed",
-        expiredSubscriptions.Count());
+    _logger.LogInformation("Expiring {Count} subscriptions past the grace window", expiredList.Count);
+
+    foreach (var subscription in expiredList)
+    {
+      try
+      {
+        subscription.Status = SubscriptionStatus.Canceled;
+        subscription.CanceledAt = DateTime.UtcNow;
+        await _unitOfWork.UserSubscriptions.UpdateAsync(subscription);
+
+        await DisableSyncConfigsForUserAsync(subscription.UserId);
+
+        _logger.LogInformation(
+          "Expired subscription {SubscriptionId} for user {UserId}; CurrentPeriodEnd was {PeriodEnd}",
+          subscription.Id, subscription.UserId, subscription.CurrentPeriodEnd);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex,
+          "Failed to expire subscription {SubscriptionId} for user {UserId}; continuing batch",
+          subscription.Id, subscription.UserId);
+      }
+    }
+  }
+
+  public async Task ReactivateSyncConfigsAsync(int userId)
+  {
+    var autoDisabled = await _unitOfWork.SyncConfigs.GetAutoDisabledByUserIdAsync(
+      userId, AutoDisableReason.SubscriptionInactive);
+    var toReenable = autoDisabled.ToList();
+
+    if (toReenable.Count == 0)
+    {
+      return;
+    }
+
+    foreach (var config in toReenable)
+    {
+      await _unitOfWork.SyncConfigs.EnableConfigAsync(config.Id);
+    }
+
+    _logger.LogInformation(
+      "Re-enabled {Count} sync configs for user {UserId} after subscription reactivation",
+      toReenable.Count, userId);
   }
 }

--- a/api/Services/Implementations/SyncSchedulerService.cs
+++ b/api/Services/Implementations/SyncSchedulerService.cs
@@ -67,7 +67,7 @@ public class SyncSchedulerService : ISyncSchedulerService
                 {
                     _logger.LogWarning("User {UserId} does not have active subscription, disabling sync config {ConfigId}",
                         config.UserId, config.Id);
-                    await _unitOfWork.SyncConfigs.DisableConfigAsync(config.Id);
+                    await _unitOfWork.SyncConfigs.DisableConfigAsync(config.Id, AutoDisableReason.SubscriptionInactive);
                     continue;
                 }
 

--- a/api/Services/Interfaces/ISubscriptionService.cs
+++ b/api/Services/Interfaces/ISubscriptionService.cs
@@ -13,5 +13,12 @@ public interface ISubscriptionService
   Task<IEnumerable<SubscriptionPlan>> GetAvailablePlansAsync();
   Task<SubscriptionPlan?> GetPlanByIdAsync(int planId);
   Task<SubscriptionPlan?> GetPlanByStripePriceIdAsync(string stripePriceId);
-  Task ValidateSubscriptionsAsync(); // For periodic validation
+  // Runs on a periodic background tick. Transitions Active → Canceled for subscriptions whose
+  // CurrentPeriodEnd is beyond the grace window, and disables enabled sync configs belonging
+  // to those users with AutoDisabledReason = SubscriptionInactive.
+  Task ValidateSubscriptionsAsync();
+  // Re-enables any sync configs that were previously auto-disabled due to subscription
+  // inactivity. Called by the webhook processor when a user's subscription transitions back
+  // to Active so their syncs resume without manual intervention.
+  Task ReactivateSyncConfigsAsync(int userId);
 }


### PR DESCRIPTION
## Summary

Fixes two correctness gaps in the subscription lifecycle. Without this pair, a user whose card briefly declines before they pay would see their subscription return to Active but all their sync configs silently stuck off — the classic one-way-trap that's worse than not expiring at all.

- **Expiry transition actually happens now.** `ValidateSubscriptionsAsync` previously only logged expired subscriptions and redundantly disabled their sync configs on every tick. It never set `Status = Canceled` or stamped `CanceledAt`, so the same rows were found and reprocessed forever. It was also never scheduled, so even the partial behavior didn't run in production. Rewritten to do the transition, filter by a 24-hour grace window past `CurrentPeriodEnd` (to avoid racing Stripe's renewal webhook), and disable only currently-enabled configs so it stays idempotent across ticks. A new hourly `SubscriptionExpiryBackgroundService` invokes it, following the pattern of `WebhookRetryBackgroundService`.
- **Re-enablement path added.** Sync configs disabled as a consequence of subscription inactivity are now tagged `AutoDisabledReason = SubscriptionInactive` (new nullable column on `PlaylistSyncConfigs`, migration `20260418184350`). When a `customer.subscription.updated` or `invoice.payment_succeeded` webhook transitions a user's subscription from a non-active state back to Active, `StripeWebhookProcessor` calls `ReactivateSyncConfigsAsync`, which re-enables only configs carrying that reason. User-initiated `DisableSyncAsync` calls leave the reason null so those are not resurrected automatically.

## Context

Tasks 1 and 2 of the subscription/payment production-readiness audit at `~/.claude/plans/audit-the-current-workflow-harmonic-platypus.md`. Bundled into one PR because Task 1 alone creates the one-way trap described above — they ship together or not at all.

## Changes

| Area | File |
|---|---|
| Domain model | `api/Models/Domain/PlaylistSyncConfig.cs` (add `AutoDisabledReason`, add `AutoDisableReason` static class) |
| Migration | `api/Migrations/20260418184350_AddAutoDisabledReasonToSyncConfig.cs` |
| Repository | `api/Infrastructure/Repositories/IPlaylistSyncConfigRepository.cs`, `PlaylistSyncConfigRepository.cs` (new `GetEnabledByUserIdAsync`, `GetAutoDisabledByUserIdAsync`, `EnableConfigAsync`; `DisableConfigAsync` gains optional reason parameter) |
| Repository | `api/Infrastructure/Repositories/IUserSubscriptionRepository.cs`, `UserSubscriptionRepository.cs` (new `GetExpiredActiveSubscriptionsAsync` with grace cutoff) |
| Service | `api/Services/Interfaces/ISubscriptionService.cs`, `api/Services/Implementations/SubscriptionService.cs` (rewrite `ValidateSubscriptionsAsync`, add `ReactivateSyncConfigsAsync`) |
| Service | `api/Services/Implementations/StripeWebhookProcessor.cs` (detect inactive → Active transitions; invoke reactivation) |
| Service | `api/Services/Implementations/PlaylistSyncService.cs`, `SyncSchedulerService.cs` (tag reason when disabling due to inactive subscription) |
| Background service | `api/Services/BackgroundServices/SubscriptionExpiryBackgroundService.cs` (new, hourly) |
| DI wiring | `api/Program.cs` |
| Tests | `api.Tests/Unit/Services/SubscriptionServiceTests.cs` (4 new tests), `PlaylistSyncServiceTests.cs` (updated mocks) |

## Test plan

- [x] `dotnet test api.Tests/Unit` — 389 tests pass (384 pre-existing + 5 new covering: expiry past grace, no-op inside grace, batch continuation on individual failure, reactivation of auto-disabled configs, reactivation no-op when none exist).
- [ ] Integration: on staging, `UPDATE UserSubscriptions SET CurrentPeriodEnd = NOW() - INTERVAL '48 hours' WHERE Id = <test>` then wait for the hourly tick — confirm `Status = 'canceled'`, `CanceledAt` populated, and the user's previously-enabled sync configs are now disabled with `AutoDisabledReason = 'subscription_inactive'`.
- [ ] Integration: on staging, `stripe trigger invoice.payment_failed` on a test subscription → confirm status becomes `past_due` and configs are tagged + disabled. Then `stripe trigger invoice.payment_succeeded` → confirm status returns to `active` and configs are re-enabled.
- [ ] Regression: existing Stripe webhook processor tests still pass.

## Notes

- Pre-existing integration test failures in `LocalSupabaseAuthenticationTests` (6 tests returning `Unauthorized`) reproduce on clean `main` and are unrelated to this change.
- The grace window is 24 hours, embedded as `SubscriptionService.ExpiryGraceWindow`. If Stripe renewal webhooks land consistently within a shorter window in practice, that constant can be tightened later.
- `CancelSubscriptionAsync` still calls `GetByUserIdAsync` + per-config `DisableConfigAsync` with the reason tagged — the explicit user-initiated cancel path still counts as "auto-disabled by subscription inactivity" for reactivation purposes (if the user re-subscribes later, their configs come back). User-initiated `DisableSyncAsync` on an individual config remains untagged, as intended.