### PR TITLE
fix(api): enforce plan limits, bound webhook tables, rate-limit checkout

### DIFF
--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RadioWash.Api.Infrastructure.Patterns;
 using RadioWash.Api.Models.Domain;
+using RadioWash.Api.Services.Exceptions;
 using RadioWash.Api.Services.Implementations;
 using Xunit;
 
@@ -425,6 +426,96 @@ public class SubscriptionServiceTests
 
     // Assert
     _mockUnitOfWork.Verify(x => x.SyncConfigs.EnableConfigAsync(It.IsAny<int>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task EnforcePlanLimitAsync_AtLimit_Throws()
+  {
+    // Arrange
+    var userId = 10;
+    var subscription = CreateUserSubscription(userId);
+    subscription.Plan = CreateSubscriptionPlanWithLimit(1, "Pro", maxPlaylists: 3);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
+        .ReturnsAsync(subscription);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.CountEnabledByUserIdAsync(userId))
+        .ReturnsAsync(3);
+
+    // Act + Assert
+    var ex = await Assert.ThrowsAsync<PlanLimitExceededException>(
+        () => _subscriptionService.EnforcePlanLimitAsync(userId));
+    Assert.Equal("playlists", ex.LimitType);
+    Assert.Equal(3, ex.Limit);
+    Assert.Equal(3, ex.Current);
+  }
+
+  [Fact]
+  public async Task EnforcePlanLimitAsync_BelowLimit_DoesNotThrow()
+  {
+    // Arrange
+    var userId = 11;
+    var subscription = CreateUserSubscription(userId);
+    subscription.Plan = CreateSubscriptionPlanWithLimit(1, "Pro", maxPlaylists: 3);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
+        .ReturnsAsync(subscription);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.CountEnabledByUserIdAsync(userId))
+        .ReturnsAsync(2);
+
+    // Act
+    await _subscriptionService.EnforcePlanLimitAsync(userId);
+
+    // Assert: no exception means success; also confirm the count was queried
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.CountEnabledByUserIdAsync(userId), Times.Once);
+  }
+
+  [Fact]
+  public async Task EnforcePlanLimitAsync_UnlimitedPlan_DoesNotQueryCount()
+  {
+    // Arrange: MaxPlaylists = null means unlimited
+    var userId = 12;
+    var subscription = CreateUserSubscription(userId);
+    subscription.Plan = CreateSubscriptionPlanWithLimit(1, "Unlimited", maxPlaylists: null);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
+        .ReturnsAsync(subscription);
+
+    // Act
+    await _subscriptionService.EnforcePlanLimitAsync(userId);
+
+    // Assert: count query should not fire when the plan is unlimited
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.CountEnabledByUserIdAsync(It.IsAny<int>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task EnforcePlanLimitAsync_NoSubscription_DoesNotThrow()
+  {
+    // Arrange: gate is HasActiveSubscriptionAsync (caller's responsibility) — EnforcePlanLimit
+    // intentionally no-ops when there's no subscription so the two error paths stay distinct
+    // at the HTTP boundary. Without this behavior the test for "at limit" can't exist as
+    // written because the code would throw for a different reason.
+    var userId = 13;
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
+        .ReturnsAsync((UserSubscription?)null);
+
+    // Act + Assert: no exception
+    await _subscriptionService.EnforcePlanLimitAsync(userId);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.CountEnabledByUserIdAsync(It.IsAny<int>()), Times.Never);
+  }
+
+  private static SubscriptionPlan CreateSubscriptionPlanWithLimit(int id, string name, int? maxPlaylists)
+  {
+    return new SubscriptionPlan
+    {
+      Id = id,
+      Name = name,
+      PriceInCents = 299,
+      BillingPeriod = "monthly",
+      IsActive = true,
+      MaxPlaylists = maxPlaylists,
+      CreatedAt = DateTime.UtcNow,
+      UpdatedAt = DateTime.UtcNow
+    };
   }
 
   private static UserSubscription CreateUserSubscription(int userId)

--- a/api/Controllers/PlaylistSyncController.cs
+++ b/api/Controllers/PlaylistSyncController.cs
@@ -64,6 +64,9 @@ public class PlaylistSyncController : AuthenticatedControllerBase
       return BadRequest(new { error = "Active subscription required to enable sync" });
     }
 
+    // Plan-limit check: throws PlanLimitExceededException, mapped to 403 by GlobalExceptionMiddleware
+    await _subscriptionService.EnforcePlanLimitAsync(userId);
+
     try
     {
       var config = await _syncService.EnableSyncForJobAsync(dto.JobId, userId);

--- a/api/Controllers/SubscriptionController.cs
+++ b/api/Controllers/SubscriptionController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using RadioWash.Api.Infrastructure.Data;
 using RadioWash.Api.Models.DTO;
 using RadioWash.Api.Services.Interfaces;
@@ -85,6 +86,7 @@ public class SubscriptionController : AuthenticatedControllerBase
   }
 
   [HttpPost("checkout")]
+  [EnableRateLimiting("checkout")]
   public async Task<ActionResult> CreateCheckoutSession([FromBody] CreateCheckoutDto dto)
   {
     var userId = GetCurrentUserId();
@@ -102,6 +104,7 @@ public class SubscriptionController : AuthenticatedControllerBase
   }
 
   [HttpPost("portal")]
+  [EnableRateLimiting("checkout")]
   public async Task<ActionResult> CreatePortalSession()
   {
     var userId = GetCurrentUserId();

--- a/api/Infrastructure/Repositories/IPlaylistSyncConfigRepository.cs
+++ b/api/Infrastructure/Repositories/IPlaylistSyncConfigRepository.cs
@@ -8,6 +8,7 @@ public interface IPlaylistSyncConfigRepository
   Task<PlaylistSyncConfig?> GetByJobIdAsync(int jobId);
   Task<IEnumerable<PlaylistSyncConfig>> GetByUserIdAsync(int userId);
   Task<IEnumerable<PlaylistSyncConfig>> GetEnabledByUserIdAsync(int userId);
+  Task<int> CountEnabledByUserIdAsync(int userId);
   Task<IEnumerable<PlaylistSyncConfig>> GetAutoDisabledByUserIdAsync(int userId, string reason);
   Task<IEnumerable<PlaylistSyncConfig>> GetDueForSyncAsync(DateTime currentTime);
   Task<IEnumerable<PlaylistSyncConfig>> GetActiveConfigsAsync();

--- a/api/Infrastructure/Repositories/PlaylistSyncConfigRepository.cs
+++ b/api/Infrastructure/Repositories/PlaylistSyncConfigRepository.cs
@@ -47,6 +47,12 @@ public class PlaylistSyncConfigRepository : IPlaylistSyncConfigRepository
         .ToListAsync();
   }
 
+  public async Task<int> CountEnabledByUserIdAsync(int userId)
+  {
+    return await _dbContext.PlaylistSyncConfigs
+        .CountAsync(psc => psc.UserId == userId && psc.IsActive);
+  }
+
   public async Task<IEnumerable<PlaylistSyncConfig>> GetAutoDisabledByUserIdAsync(int userId, string reason)
   {
     return await _dbContext.PlaylistSyncConfigs

--- a/api/Middleware/GlobalExceptionMiddleware.cs
+++ b/api/Middleware/GlobalExceptionMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Text.Json;
+using RadioWash.Api.Services.Exceptions;
 
 namespace RadioWash.Api.Middleware;
 
@@ -58,6 +59,28 @@ public class GlobalExceptionMiddleware
         {
             context.Response.Clear();
             context.Response.ContentType = "application/json";
+
+            // Expected business-rule exception: return a 403 Problem Details body with the
+            // limit fields populated so the UI can render a specific message. These fields
+            // are the whole purpose of the exception — safe to expose in all environments.
+            if (exception is PlanLimitExceededException planLimit)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                var problem = new
+                {
+                    type = "https://radiowash.app/problems/plan-limit-exceeded",
+                    title = "Plan limit exceeded",
+                    status = (int)HttpStatusCode.Forbidden,
+                    detail = planLimit.Message,
+                    limitType = planLimit.LimitType,
+                    limit = planLimit.Limit,
+                    current = planLimit.Current,
+                    traceId,
+                };
+                await context.Response.WriteAsync(JsonSerializer.Serialize(problem));
+                return;
+            }
+
             context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 
             // Only expose exception.Message to clients in Development. In Production/Staging

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -340,6 +340,47 @@ if (!builder.Environment.IsEnvironment("Testing") && !builder.Environment.IsEnvi
 // Background services
 builder.Services.AddHostedService<WebhookRetryBackgroundService>();
 builder.Services.AddHostedService<SubscriptionExpiryBackgroundService>();
+builder.Services.AddHostedService<WebhookTableRetentionBackgroundService>();
+
+// Rate limiting: per-authenticated-user bucket for subscription checkout/portal endpoints.
+// The Stripe webhook endpoint is deliberately NOT rate-limited — Stripe retries aggressively
+// during outage recovery from a small pool of egress IPs, and a 429 would cause Stripe to
+// eventually give up within its retry window, creating the silent state drift we're trying
+// to prevent. Signature verification + idempotency already gate that endpoint.
+builder.Services.AddRateLimiter(options =>
+{
+    options.AddPolicy("checkout", httpContext =>
+    {
+        var userId = httpContext.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                     ?? httpContext.User?.FindFirst("sub")?.Value;
+        var partitionKey = string.IsNullOrEmpty(userId) ? "__anonymous__" : userId;
+        return System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey,
+            _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 5,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            });
+    });
+
+    options.OnRejected = async (context, cancellationToken) =>
+    {
+        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        context.HttpContext.Response.ContentType = "application/json";
+        var problem = new
+        {
+            type = "https://radiowash.app/problems/rate-limit-exceeded",
+            title = "Too many requests",
+            status = StatusCodes.Status429TooManyRequests,
+            detail = "You've issued too many requests in a short period. Please wait a moment and try again."
+        };
+        await context.HttpContext.Response.WriteAsync(
+            System.Text.Json.JsonSerializer.Serialize(problem),
+            cancellationToken);
+    };
+});
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -476,6 +517,7 @@ app.UseMiddleware<RadioWash.Api.Middleware.GlobalExceptionMiddleware>();
 app.UseAuthentication();
 app.UseMiddleware<RadioWash.Api.Middleware.TokenRefreshMiddleware>();
 app.UseAuthorization();
+app.UseRateLimiter();
 app.MapControllers();
 app.MapHub<PlaylistProgressHub>("/hubs/playlist-progress", options =>
 {

--- a/api/Services/BackgroundServices/WebhookTableRetentionBackgroundService.cs
+++ b/api/Services/BackgroundServices/WebhookTableRetentionBackgroundService.cs
@@ -1,0 +1,117 @@
+using Microsoft.EntityFrameworkCore;
+using RadioWash.Api.Infrastructure.Data;
+using RadioWash.Api.Models.Domain;
+
+namespace RadioWash.Api.Services.BackgroundServices;
+
+// Trims ProcessedWebhookEvents and WebhookRetries to a 90-day window so these audit/retry
+// tables don't grow unbounded. Deletes are batched to keep lock windows short enough that
+// concurrent webhook writes aren't starved.
+public class WebhookTableRetentionBackgroundService : BackgroundService
+{
+    // Runs daily. An hourly cadence would shrink the working set faster but adds churn to
+    // the audit index for little real gain at the current event volume.
+    private static readonly TimeSpan ProcessingInterval = TimeSpan.FromDays(1);
+    private static readonly TimeSpan RetentionWindow = TimeSpan.FromDays(90);
+    private const int BatchSize = 1000;
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<WebhookTableRetentionBackgroundService> _logger;
+
+    public WebhookTableRetentionBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<WebhookTableRetentionBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("WebhookTableRetentionBackgroundService started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await PruneOnceAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error pruning webhook tables: {ErrorMessage}", ex.Message);
+            }
+
+            try
+            {
+                await Task.Delay(ProcessingInterval, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("WebhookTableRetentionBackgroundService stopped");
+    }
+
+    private async Task PruneOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<RadioWashDbContext>();
+
+        var cutoff = DateTime.UtcNow - RetentionWindow;
+
+        var processedDeleted = await PruneProcessedEventsAsync(dbContext, cutoff, cancellationToken);
+        var retriesDeleted = await PruneTerminalRetriesAsync(dbContext, cutoff, cancellationToken);
+
+        if (processedDeleted > 0 || retriesDeleted > 0)
+        {
+            _logger.LogInformation(
+                "Pruned webhook tables: {ProcessedCount} processed events, {RetryCount} retries older than {Cutoff:O}",
+                processedDeleted, retriesDeleted, cutoff);
+        }
+    }
+
+    private static async Task<int> PruneProcessedEventsAsync(RadioWashDbContext dbContext, DateTime cutoff, CancellationToken cancellationToken)
+    {
+        var totalDeleted = 0;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var deleted = await dbContext.ProcessedWebhookEvents
+                .Where(pwe => pwe.ProcessedAt < cutoff)
+                .OrderBy(pwe => pwe.ProcessedAt)
+                .Take(BatchSize)
+                .ExecuteDeleteAsync(cancellationToken);
+
+            totalDeleted += deleted;
+            if (deleted < BatchSize)
+            {
+                break;
+            }
+        }
+        return totalDeleted;
+    }
+
+    private static async Task<int> PruneTerminalRetriesAsync(RadioWashDbContext dbContext, DateTime cutoff, CancellationToken cancellationToken)
+    {
+        var totalDeleted = 0;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var deleted = await dbContext.WebhookRetries
+                .Where(wr => (wr.Status == WebhookRetryStatus.Succeeded
+                              || wr.Status == WebhookRetryStatus.Failed
+                              || wr.Status == WebhookRetryStatus.MaxRetriesExceeded)
+                              && wr.UpdatedAt < cutoff)
+                .OrderBy(wr => wr.UpdatedAt)
+                .Take(BatchSize)
+                .ExecuteDeleteAsync(cancellationToken);
+
+            totalDeleted += deleted;
+            if (deleted < BatchSize)
+            {
+                break;
+            }
+        }
+        return totalDeleted;
+    }
+}

--- a/api/Services/Exceptions/PlanLimitExceededException.cs
+++ b/api/Services/Exceptions/PlanLimitExceededException.cs
@@ -1,0 +1,20 @@
+namespace RadioWash.Api.Services.Exceptions;
+
+// Thrown by SubscriptionService.EnforcePlanLimitAsync when a user at their plan's limit
+// attempts to create another resource. The middleware maps this to HTTP 403 with a
+// Problem Details body that surfaces both limit and current count so the UI can render
+// a specific message instead of a generic error.
+public class PlanLimitExceededException : Exception
+{
+    public string LimitType { get; }
+    public int Limit { get; }
+    public int Current { get; }
+
+    public PlanLimitExceededException(string limitType, int limit, int current)
+        : base($"Plan limit exceeded: {current}/{limit} {limitType}")
+    {
+        LimitType = limitType;
+        Limit = limit;
+        Current = current;
+    }
+}

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -1,5 +1,6 @@
 using RadioWash.Api.Infrastructure.Patterns;
 using RadioWash.Api.Models.Domain;
+using RadioWash.Api.Services.Exceptions;
 using RadioWash.Api.Services.Interfaces;
 
 namespace RadioWash.Api.Services.Implementations;
@@ -188,5 +189,26 @@ public class SubscriptionService : ISubscriptionService
     _logger.LogInformation(
       "Re-enabled {Count} sync configs for user {UserId} after subscription reactivation",
       toReenable.Count, userId);
+  }
+
+  public async Task EnforcePlanLimitAsync(int userId)
+  {
+    var subscription = await _unitOfWork.UserSubscriptions.GetByUserIdAsync(userId);
+    if (subscription?.Plan == null)
+    {
+      return;
+    }
+
+    var maxPlaylists = subscription.Plan.MaxPlaylists;
+    if (!maxPlaylists.HasValue)
+    {
+      return;
+    }
+
+    var current = await _unitOfWork.SyncConfigs.CountEnabledByUserIdAsync(userId);
+    if (current >= maxPlaylists.Value)
+    {
+      throw new PlanLimitExceededException("playlists", maxPlaylists.Value, current);
+    }
   }
 }

--- a/api/Services/Interfaces/ISubscriptionService.cs
+++ b/api/Services/Interfaces/ISubscriptionService.cs
@@ -21,4 +21,10 @@ public interface ISubscriptionService
   // inactivity. Called by the webhook processor when a user's subscription transitions back
   // to Active so their syncs resume without manual intervention.
   Task ReactivateSyncConfigsAsync(int userId);
+  // Verifies the user's enabled sync-config count is strictly less than their plan's
+  // MaxPlaylists before creating another one. Throws PlanLimitExceededException when at
+  // or above the limit. A null MaxPlaylists means unlimited and is always allowed. No
+  // active subscription leaves this method as a no-op; callers gate that separately with
+  // HasActiveSubscriptionAsync so the two error paths stay distinct at the HTTP boundary.
+  Task EnforcePlanLimitAsync(int userId);
 }


### PR DESCRIPTION
## Summary

Three related hardening changes on the subscription and payment path, bundled because they all touch the same DI wiring in \`Program.cs\` and \`SubscriptionController\` — keeping them together avoids merge-order churn.

### 1. Server-side plan limits (Task 3)

\`PlaylistSyncController.EnableSync\` now calls \`SubscriptionService.EnforcePlanLimitAsync\` after the existing subscription gate. The new method compares the user's enabled-config count against \`SubscriptionPlan.MaxPlaylists\` and throws \`PlanLimitExceededException\` when at or above the limit. Until now the limit was a client-side suggestion only — a user could bypass it with a raw API call.

- \`null\` MaxPlaylists means unlimited (no-op, no count query).
- Missing subscription is a no-op because \`HasActiveSubscriptionAsync\` already gates that path. Keeping the two error surfaces distinct keeps HTTP semantics clean.
- \`GlobalExceptionMiddleware\` maps the exception to **HTTP 403** with a Problem Details body that surfaces \`limit\`, \`current\`, and \`limitType\` so the UI can render a specific \"You're at your plan limit (N/N)\" message rather than a generic error.

### 2. Webhook table retention (Task 4)

A new daily \`WebhookTableRetentionBackgroundService\` prunes:
- \`ProcessedWebhookEvents\` rows older than 90 days (by \`ProcessedAt\`).
- \`WebhookRetries\` rows in a terminal status (\`Succeeded\` / \`Failed\` / \`MaxRetriesExceeded\`) whose \`UpdatedAt\` is older than 90 days.

Deletes are batched in chunks of 1000 rows via \`ExecuteDeleteAsync\` to keep lock windows short enough not to starve concurrent webhook writes. Without this, the tables grew unbounded — they're primarily for short-lived idempotency and retry state.

### 3. Rate limit checkout and portal (Task 5)

.NET 8 \`AddRateLimiter\` wired with a single \`checkout\` policy: 5 requests per authenticated user per minute, fixed window, no queue. Applied via \`[EnableRateLimiting(\"checkout\")]\` to \`CreateCheckoutSession\` and \`CreatePortalSession\`.

**The Stripe webhook endpoint is deliberately NOT rate-limited.** Stripe retries aggressively during outage recovery from a small pool of egress IPs; a 429 from us would cause Stripe to eventually give up within its retry window, creating the same silent state drift this audit is meant to prevent. Signature verification + idempotency already gate that endpoint.

\`app.UseRateLimiter()\` is placed after \`UseAuthorization\` so the partition key can read \`HttpContext.User\`. \`OnRejected\` returns 429 with a Problem Details body mirroring the 403 format.

## Context

Tasks 3, 4, and 5 of the subscription/payment production-readiness audit at \`~/.claude/plans/audit-the-current-workflow-harmonic-platypus.md\`. Previous PRs in this series: #56 (Sentry token hardening), #57 (subscription expiry + reactivation).

## Changes

| Area | File |
|---|---|
| Exception | \`api/Services/Exceptions/PlanLimitExceededException.cs\` (new) |
| Service interface | \`api/Services/Interfaces/ISubscriptionService.cs\` (add \`EnforcePlanLimitAsync\`) |
| Service impl | \`api/Services/Implementations/SubscriptionService.cs\` |
| Repository | \`api/Infrastructure/Repositories/IPlaylistSyncConfigRepository.cs\`, \`PlaylistSyncConfigRepository.cs\` (add \`CountEnabledByUserIdAsync\`) |
| Controller | \`api/Controllers/PlaylistSyncController.cs\` (invoke enforcement) |
| Controller | \`api/Controllers/SubscriptionController.cs\` (rate-limit attributes) |
| Middleware | \`api/Middleware/GlobalExceptionMiddleware.cs\` (map exception to 403 Problem Details) |
| Background | \`api/Services/BackgroundServices/WebhookTableRetentionBackgroundService.cs\` (new) |
| DI wiring | \`api/Program.cs\` (\`AddRateLimiter\`, \`UseRateLimiter\`, \`AddHostedService\`) |
| Tests | \`api.Tests/Unit/Services/SubscriptionServiceTests.cs\` (4 new tests) |

## Test plan

- [x] \`dotnet test api.Tests/Unit\` — **393 tests pass** (389 prior + 4 new covering at-limit, below-limit, unlimited-plan, no-subscription paths of \`EnforcePlanLimitAsync\`).
- [ ] Manual: staging, at-limit user attempts \`POST /api/playlistsync/enable\` → 403 Problem Details body contains \`limit\` and \`current\` extension fields.
- [ ] Manual: staging, issue 6 rapid \`POST /api/subscription/checkout\` requests as one authenticated user → 6th returns 429 Problem Details. Separate user in parallel is unaffected.
- [ ] Manual: staging, fire 200+ Stripe webhooks via \`stripe listen --forward-to\` in rapid succession → all processed or queued, zero 429s on the webhook endpoint.
- [ ] Manual: staging, seed a \`ProcessedWebhookEvents\` row with \`ProcessedAt = NOW() - INTERVAL '91 days'\` and a recent row; wait for retention tick (or invoke via test trigger) → old row deleted, recent row retained.

## Notes

- The existing pre-commit \`PlaylistSyncControllerTests\` continue to pass without updates because Moq's default for unmocked async \`Task\`-returning methods is a completed task — the new \`EnforcePlanLimitAsync\` call is a no-op under their test mocks.
- The rate-limit partition uses \`ClaimTypes.NameIdentifier\` with a \`sub\` fallback. If neither claim is present (would only happen for anonymous callers, which \`[Authorize]\` already blocks), the request shares an \`__anonymous__\` bucket. Belt-and-suspenders.
- Pre-existing \`LocalSupabaseAuthenticationTests\` integration failures (6 tests returning \`Unauthorized\`) continue to reproduce on clean \`main\` and are unrelated to this PR.