### PR TITLE
feat(web): add Manage Billing button for Stripe Customer Portal

### DIFF
--- a/web/src/app/hooks/useSubscriptionSync.ts
+++ b/web/src/app/hooks/useSubscriptionSync.ts
@@ -1,15 +1,16 @@
 'use client';
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { 
-  getSubscriptionStatus, 
+import {
+  getSubscriptionStatus,
   getCurrentSubscription,
-  enableSyncForJob, 
+  enableSyncForJob,
   subscribeToSync,
+  createPortalSession,
   getSyncConfigs,
   type SubscriptionStatus,
   type UserSubscriptionDto,
-  type PlaylistSyncConfig 
+  type PlaylistSyncConfig
 } from '../services/api';
 
 export const useSubscriptionStatus = () => {
@@ -41,12 +42,25 @@ export const useEnableSyncForJob = () => {
 
 export const useSubscribeToSync = () => {
   const queryClient = useQueryClient();
-  
+
   return useMutation<{ checkoutUrl: string }, Error>({
     mutationFn: subscribeToSync,
     onSuccess: (data) => {
       // Redirect to Stripe checkout
       window.location.href = data.checkoutUrl;
+    },
+  });
+};
+
+// Opens the Stripe Customer Portal so users can update payment methods, download
+// invoices, and cancel the subscription outside of our own cancel flow. The API
+// returns a one-time portal URL; we navigate away immediately so React Query
+// cache invalidation isn't needed — the subscription page will refetch on return.
+export const useCreatePortalSession = () => {
+  return useMutation<{ portalUrl: string }, Error>({
+    mutationFn: createPortalSession,
+    onSuccess: (data) => {
+      window.location.assign(data.portalUrl);
     },
   });
 };

--- a/web/src/app/services/api.ts
+++ b/web/src/app/services/api.ts
@@ -316,6 +316,12 @@ export const cancelSubscription = (): Promise<{ success: boolean }> => {
   });
 };
 
+export const createPortalSession = (): Promise<{ portalUrl: string }> => {
+  return fetchWithSupabaseAuth(`${API_BASE_URL}/subscription/portal`, {
+    method: 'POST',
+  });
+};
+
 // --- Sync Management API Functions ---
 export const enableSyncForJob = (jobId: number): Promise<PlaylistSyncConfig> => {
   return fetchWithSupabaseAuth(`${API_BASE_URL}/playlistsync/enable`, {

--- a/web/src/app/subscription/__tests__/subscription-client.test.tsx
+++ b/web/src/app/subscription/__tests__/subscription-client.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { QueryWrapper } from '../../test-utils/react-query-wrapper';
+import { SubscriptionClient } from '../subscription-client';
+import * as subscriptionHooks from '../../hooks/useSubscriptionSync';
+import * as api from '../../services/api';
+import type { User } from '../../services/api';
+
+// Next navigation is used by router.push; a noop mock keeps the component renderable
+// without a Next.js runtime.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// GlobalHeader pulls in next/link and auth context — stub it out so the test stays
+// focused on the subscription actions. The mock target must match the exact specifier
+// used in the component under test.
+vi.mock('@/components/GlobalHeader', () => ({
+  GlobalHeader: () => <div data-testid="global-header" />,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockUser: User = {
+  id: 1,
+  spotifyId: 'spotify-1',
+  displayName: 'Test User',
+  email: 'user@example.com',
+};
+
+describe('SubscriptionClient — Manage Billing button', () => {
+  let createPortalSessionSpy: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPortalSessionSpy = vi.fn().mockResolvedValue({
+      portalUrl: 'https://billing.stripe.com/session/test',
+    });
+    vi.spyOn(api, 'createPortalSession').mockImplementation(createPortalSessionSpy);
+
+    // window.location.assign is read-only on jsdom's default Location, so stub the whole
+    // object. The original is restored by vi.unstubAllGlobals between tests.
+    vi.stubGlobal('location', {
+      ...window.location,
+      assign: vi.fn(),
+    });
+  });
+
+  it('renders the Manage Billing button when the user has an active subscription', () => {
+    vi.spyOn(subscriptionHooks, 'useSubscriptionStatus').mockReturnValue({
+      data: {
+        hasActiveSubscription: true,
+        planName: 'Sync Plan',
+        status: 'active',
+      },
+      isLoading: false,
+    } as ReturnType<typeof subscriptionHooks.useSubscriptionStatus>);
+
+    render(
+      <QueryWrapper>
+        <SubscriptionClient initialUser={mockUser} />
+      </QueryWrapper>
+    );
+
+    expect(screen.getByRole('button', { name: /manage billing/i })).toBeInTheDocument();
+  });
+
+  it('does not render the Manage Billing button when there is no active subscription', () => {
+    vi.spyOn(subscriptionHooks, 'useSubscriptionStatus').mockReturnValue({
+      data: { hasActiveSubscription: false },
+      isLoading: false,
+    } as ReturnType<typeof subscriptionHooks.useSubscriptionStatus>);
+
+    render(
+      <QueryWrapper>
+        <SubscriptionClient initialUser={mockUser} />
+      </QueryWrapper>
+    );
+
+    expect(screen.queryByRole('button', { name: /manage billing/i })).not.toBeInTheDocument();
+  });
+
+  it('calls createPortalSession and redirects to the returned portalUrl on click', async () => {
+    vi.spyOn(subscriptionHooks, 'useSubscriptionStatus').mockReturnValue({
+      data: {
+        hasActiveSubscription: true,
+        planName: 'Sync Plan',
+        status: 'active',
+      },
+      isLoading: false,
+    } as ReturnType<typeof subscriptionHooks.useSubscriptionStatus>);
+
+    const user = userEvent.setup();
+    render(
+      <QueryWrapper>
+        <SubscriptionClient initialUser={mockUser} />
+      </QueryWrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: /manage billing/i }));
+
+    await waitFor(() => {
+      expect(createPortalSessionSpy).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(window.location.assign).toHaveBeenCalledWith(
+        'https://billing.stripe.com/session/test'
+      );
+    });
+  });
+});

--- a/web/src/app/subscription/subscription-client.tsx
+++ b/web/src/app/subscription/subscription-client.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import {
   useSubscriptionStatus,
   useSubscribeToSync,
+  useCreatePortalSession,
 } from '@/hooks/useSubscriptionSync';
 import { cancelSubscription, type User } from '../services/api';
 import { toast } from 'sonner';
@@ -22,6 +23,7 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
 
   const { data: subscriptionStatus, isLoading } = useSubscriptionStatus();
   const subscribeToSyncMutation = useSubscribeToSync();
+  const portalSessionMutation = useCreatePortalSession();
 
   const cancelSubscriptionMutation = useMutation<{ success: boolean }, Error>({
     mutationFn: cancelSubscription,
@@ -35,6 +37,22 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
       console.error('Cancel subscription error:', error);
     },
   });
+
+  const handleManageBilling = async () => {
+    try {
+      await portalSessionMutation.mutateAsync();
+      // The mutation redirects on success; this line is unreachable in the happy path.
+    } catch (error) {
+      // The checkout/portal endpoints are rate-limited server-side (5/min/user); surface
+      // that specifically so users know to wait rather than assume something is broken.
+      if (error instanceof Error && error.message.includes('429')) {
+        toast.error('Too many requests. Please wait a moment and try again.');
+      } else {
+        toast.error('Unable to open billing portal. Please try again.');
+      }
+      console.error('Portal session error:', error);
+    }
+  };
 
   const handleSubscribe = async () => {
     try {
@@ -158,6 +176,15 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
                   onClick={() => router.push('/dashboard')}
                 >
                   Back to Dashboard
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={handleManageBilling}
+                  disabled={portalSessionMutation.isPending}
+                >
+                  {portalSessionMutation.isPending
+                    ? 'Opening portal...'
+                    : 'Manage Billing'}
                 </Button>
                 <Button
                   variant="destructive"


### PR DESCRIPTION
## Summary

Until now the only self-serve subscription control in the app was Cancel. That meant users couldn't update a failing payment method, download invoices, or see their billing history without contacting support — which also meant our only recovery path for a past-due subscription was \"wait for the user to complain.\"

This PR adds a **Manage Billing** button next to the existing Cancel on the subscription page that opens the Stripe Customer Portal. The portal handles payment-method updates, invoice history, and cancellation from Stripe's side, and the resulting \`customer.subscription.updated\` webhook flows back through the processor the API already ships (including the reactivation path added in PR #57).

## Wiring

- **\`web/src/app/services/api.ts\`** — \`createPortalSession()\` POSTs to \`/api/subscription/portal\` and returns \`{ portalUrl }\`. The backend endpoint already exists and is rate-limited (5/min/user, per PR #58).
- **\`web/src/app/hooks/useSubscriptionSync.ts\`** — \`useCreatePortalSession\` mutation. On success, \`window.location.assign(portalUrl)\`. No React Query invalidation needed because the user leaves the page immediately; subscription state is refetched on return.
- **\`web/src/app/subscription/subscription-client.tsx\`** — renders the button next to Cancel when \`hasActiveSubscription\`. Errors surface via sonner toast, with a specific message for HTTP 429 so users know to wait rather than assume something is broken.

## Context

Task 6 of the subscription/payment production-readiness audit at \`~/.claude/plans/audit-the-current-workflow-harmonic-platypus.md\`. Previous PRs in this series:
- #56 — Sentry token hardening
- #57 — Subscription expiry + reactivation
- #58 — Plan limits, webhook retention, rate limiting

## Test plan

- [x] \`vitest run subscription-client\` — 3 new component tests pass (renders when active, hidden when inactive, click invokes mutation and redirects).
- [x] Full web suite — 61 tests pass (58 prior + 3 new).
- [ ] Manual: staging, click **Manage Billing** as an active subscriber → redirects to \`billing.stripe.com\` portal. Confirm cancel-via-portal round-trips through the webhook processor and eventually disables sync configs.
- [ ] Manual: staging, fire 6 portal clicks in under a minute → 6th surfaces the \"Too many requests\" toast (from the 429 rate-limit policy added in #58).
- [ ] Manual: ensure the button is hidden for a user without an active subscription (they see the marketing/subscribe view instead).

## Notes

- The mutation uses \`window.location.assign\` rather than \`window.location.href =\` to match the spec in the plan and because \`assign\` is marginally easier to mock under jsdom (the test stubs the whole \`location\` object so either would work).
- \`queryClient\` is no longer needed in \`useCreatePortalSession\` since there's nothing to invalidate — caller leaves the tab. Matches the existing \`useSubscribeToSync\` shape for consistency, minus the unused \`queryClient\`. The lint warning about unused \`queryClient\` in \`useSubscribeToSync\` is pre-existing.