### PR TITLE
hotfix: wire DB connection + Hangfire admins from secrets, add .dockerignore

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -51,16 +51,16 @@ jobs:
             az webapp config appsettings set --resource-group radio-wash_group --name radiowash-api --settings \
             "Spotify__ClientId=${{ secrets.SPOTIFY_CLIENT_ID }}" \
             "Spotify__ClientSecret=${{ secrets.SPOTIFY_CLIENT_SECRET }}" \
-            "Jwt__Secret=${{ secrets.JWT_SECRET }}" \
             "Supabase__Url=${{ secrets.SUPABASE_URL }}" \
             "Supabase__PublicUrl=${{ secrets.SUPABASE_PUBLIC_URL }}" \
             "Supabase__AnonKey=${{ secrets.SUPABASE_ANON_KEY }}" \
             "Supabase__ServiceRoleKey=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
-            "Supabase__JwtSecret=${{ secrets.SUPABASE_JWT_SECRET }}" \
             "Supabase__JwtIssuer=${{ secrets.SUPABASE_JWT_ISSUER }}" \
             "FrontendUrl=${{ secrets.WEB_URL }}" \
             "Sentry__Dsn=${{ secrets.SENTRY_DSN }}" \
             "Stripe__SecretKey=${{ secrets.STRIPE_SECRET_KEY }}" \
             "Stripe__PublishableKey=${{ secrets.STRIPE_PUBLISHABLE_KEY }}" \
             "Stripe__WebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }}" \
-            "Stripe__PricePlanId=${{ secrets.STRIPE_PRICE_PLAN_ID }}"
+            "Stripe__PricePlanId=${{ secrets.STRIPE_PRICE_PLAN_ID }}" \
+            "ConnectionStrings__DefaultConnection=${{ secrets.SUPABASE_DB_CONNECTION }}" \
+            "Hangfire__AdminUserIds__0=${{ secrets.HANGFIRE_ADMIN_USER_ID_0 }}"

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,22 @@
+# Never bake local secrets into the container image. Azure App Service (or any
+# host) must inject these as environment variables at runtime.
+appsettings.*.json
+!appsettings.example.json
+
+# Build outputs (already in the container's /app from `dotnet publish`).
+bin/
+obj/
+
+# Tests don't belong in the runtime image.
+**/*.Tests/
+**/*.Tests.*/
+
+# IDE / tooling
+.vs/
+.vscode/
+*.user
+.idea/
+
+# Local runtime state
+.env
+.env.*


### PR DESCRIPTION
## Summary

Prod is currently broken because secrets were rotated without a matching deploy — the live container is still baked with the old Supabase DB password from the image layer. This PR moves the load-bearing config out of the image and into runtime env vars so future rotations don't require a container rebuild.

- Wire \`ConnectionStrings__DefaultConnection\` from a new \`SUPABASE_DB_CONNECTION\` GitHub Secret so the DB password can be rotated without rebuilding the container. This is the fix for the current outage.
- Wire \`Hangfire__AdminUserIds__0\` from \`HANGFIRE_ADMIN_USER_ID_0\` so the dashboard is actually reachable in prod (it's been fail-closed to everyone since PR #54).
- Add \`api/.dockerignore\` so \`docker build ./api\` never bakes local \`appsettings.*.json\` into the image. Removes the future leak vector of a working-tree secret shipping to Azure.
- Drop \`Jwt__Secret\` and \`Supabase__JwtSecret\` — neither is consumed in prod. \`Jwt.Secret\` has no reader in the codebase (custom JWT path was replaced by Supabase), and \`Supabase__JwtSecret\` is ignored by the \`SupabaseJwtPolicy\` gate that landed in #54.

## Required before merge

These GitHub Secrets must exist or the deploy will set empty values:

- **Add** \`SUPABASE_DB_CONNECTION\` = full connection string with the rotated password
- **Add** \`HANGFIRE_ADMIN_USER_ID_0\` = \`\`
- **Rotate / update** \`SUPABASE_ANON_KEY\` (\`sb_publishable_…\`), \`SUPABASE_SERVICE_ROLE_KEY\` (\`sb_secret_…\`), \`STRIPE_SECRET_KEY\`, \`STRIPE_WEBHOOK_SECRET\`, \`STRIPE_PUBLISHABLE_KEY\`

**Can be deleted after merge:** \`JWT_SECRET\`, \`SUPABASE_JWT_SECRET\`.

## Test plan

- [ ] Confirm all required secrets above are present in repo settings before merging
- [ ] Merge triggers \`Deploy API to Azure App Service\` workflow — watch the \`Set API app settings\` step for any missing-secret warnings
- [ ] After deploy: \`curl https://radiowash-api.azurewebsites.net/healthz\` returns 200 (DB connection works with the new password)
- [ ] With a valid admin bearer token, \`/hangfire\` loads; without one, 401/403
- [ ] Trigger a Stripe test webhook — \`StripeWebhookProcessor\` validates with the new \`whsec_\`