### PR TITLE
feat: user-facing provider disconnect

### DIFF
--- a/api.Tests/Unit/Controllers/AuthControllerTests.cs
+++ b/api.Tests/Unit/Controllers/AuthControllerTests.cs
@@ -161,7 +161,10 @@ public class AuthControllerTests
     var tokensRevokedValue = tokensRevokedProperty?.GetValue(response);
     Assert.Equal(true, tokensRevokedValue);
 
+    // Every supported provider, not just Spotify — the hardcoded list previously left
+    // Apple Music connected after a "revoke everything" logout on a shared device.
     _mockMusicTokenService.Verify(x => x.RevokeTokensAsync(user.Id, "spotify"), Times.Once);
+    _mockMusicTokenService.Verify(x => x.RevokeTokensAsync(user.Id, "apple_music"), Times.Once);
   }
 
   [Fact]
@@ -218,6 +221,46 @@ public class AuthControllerTests
             It.IsAny<Exception>(),
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
         Times.Once);
+  }
+
+  [Fact]
+  public async Task DisconnectProvider_RevokesTheStoredTokens()
+  {
+    var userId = Guid.NewGuid();
+    var user = CreateTestUserDto();
+    SetupAuthenticatedUser(userId);
+    _mockUserService.Setup(x => x.GetUserBySupabaseIdAsync(userId)).ReturnsAsync(user);
+
+    var result = await _authController.DisconnectProvider("apple_music");
+
+    Assert.IsType<OkObjectResult>(result);
+    _mockMusicTokenService.Verify(x => x.RevokeTokensAsync(user.Id, "apple_music"), Times.Once);
+  }
+
+  [Fact]
+  public async Task DisconnectProvider_NormalizesTheProviderKey()
+  {
+    var userId = Guid.NewGuid();
+    var user = CreateTestUserDto();
+    SetupAuthenticatedUser(userId);
+    _mockUserService.Setup(x => x.GetUserBySupabaseIdAsync(userId)).ReturnsAsync(user);
+
+    var result = await _authController.DisconnectProvider("SPOTIFY");
+
+    Assert.IsType<OkObjectResult>(result);
+    _mockMusicTokenService.Verify(x => x.RevokeTokensAsync(user.Id, "spotify"), Times.Once);
+  }
+
+  [Fact]
+  public async Task DisconnectProvider_WithUnsupportedProvider_ReturnsBadRequest()
+  {
+    var userId = Guid.NewGuid();
+    SetupAuthenticatedUser(userId);
+
+    var result = await _authController.DisconnectProvider("winamp");
+
+    Assert.IsType<BadRequestObjectResult>(result);
+    _mockMusicTokenService.Verify(x => x.RevokeTokensAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
   }
 
   private void SetupAuthenticatedUser(Guid userId)

--- a/api.Tests/Unit/Services/SyncSchedulerServiceTests.cs
+++ b/api.Tests/Unit/Services/SyncSchedulerServiceTests.cs
@@ -1,0 +1,78 @@
+using Hangfire;
+using Hangfire.Common;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RadioWash.Api.Infrastructure.Patterns;
+using RadioWash.Api.Services.Implementations;
+using RadioWash.Api.Services.Interfaces;
+
+namespace RadioWash.Api.Tests.Unit.Services;
+
+/// <summary>
+/// Tests for the startup-time recurring-job registration. Registration is idempotent and
+/// the definitions persist in Hangfire storage, so the contract under test is resilience:
+/// a failing AddOrUpdate (e.g. a distributed-lock timeout left by an unclean shutdown)
+/// must not escape and take the API down, and must not stop the other jobs from
+/// registering.
+/// </summary>
+public class SyncSchedulerServiceTests
+{
+  private readonly Mock<IRecurringJobManager> _recurringJobManager = new();
+  private readonly Mock<IBackgroundJobClient> _backgroundJobClient = new();
+  private readonly Mock<IUnitOfWork> _unitOfWork = new();
+  private readonly Mock<ISubscriptionService> _subscriptionService = new();
+  private readonly Mock<ILogger<SyncSchedulerService>> _logger = new();
+  private readonly SyncSchedulerService _service;
+
+  public SyncSchedulerServiceTests()
+  {
+    _service = new SyncSchedulerService(
+      _recurringJobManager.Object,
+      _backgroundJobClient.Object,
+      _unitOfWork.Object,
+      _subscriptionService.Object,
+      _logger.Object);
+  }
+
+  [Fact]
+  public void InitializeScheduledJobs_RegistersBothRecurringJobs()
+  {
+    _service.InitializeScheduledJobs();
+
+    _recurringJobManager.Verify(m => m.AddOrUpdate(
+      "playlist-sync-processor", It.IsAny<Job>(), "1 0 * * *", It.IsAny<RecurringJobOptions>()), Times.Once);
+    _recurringJobManager.Verify(m => m.AddOrUpdate(
+      "subscription-validator", It.IsAny<Job>(), "0 2 * * *", It.IsAny<RecurringJobOptions>()), Times.Once);
+  }
+
+  [Fact]
+  public void InitializeScheduledJobs_SurvivesARegistrationFailureAndRegistersTheRemainingJobs()
+  {
+    // The real-world shape: an API instance killed while holding Hangfire's distributed
+    // lock leaves the lock row orphaned; until the 10-minute staleness cutoff passes,
+    // AddOrUpdate for that job times out. This used to escape as an unhandled exception
+    // in Program and crash-loop the API on every quick restart.
+    _recurringJobManager
+      .Setup(m => m.AddOrUpdate(
+        "playlist-sync-processor", It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<RecurringJobOptions>()))
+      .Throws(new TimeoutException(
+        "Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the " +
+        "'hangfire:lock:recurring-job:playlist-sync-processor' resource."));
+
+    var exception = Record.Exception(() => _service.InitializeScheduledJobs());
+
+    Assert.Null(exception);
+    // The failure is isolated: the other job still registers.
+    _recurringJobManager.Verify(m => m.AddOrUpdate(
+      "subscription-validator", It.IsAny<Job>(), "0 2 * * *", It.IsAny<RecurringJobOptions>()), Times.Once);
+    // And it is loud, not swallowed.
+    _logger.Verify(
+      x => x.Log(
+        LogLevel.Error,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("playlist-sync-processor")),
+        It.IsAny<Exception>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+      Times.Once);
+  }
+}

--- a/api/Controllers/AuthController.cs
+++ b/api/Controllers/AuthController.cs
@@ -156,6 +156,49 @@ public class AuthController : ControllerBase
   }
 
   /// <summary>
+  /// Disconnects a music provider by deleting the tokens stored for the authenticated user.
+  /// This is the extent of what the server can do: neither provider supports revoking the
+  /// credential itself from here — Spotify has no OAuth revocation endpoint (users remove
+  /// the app at spotify.com/account/apps) and Apple Music User Tokens are managed in Apple's
+  /// settings. The frontend additionally drops the browser-side MusicKit grant for Apple.
+  /// Idempotent: disconnecting an already-disconnected provider succeeds.
+  /// </summary>
+  [HttpDelete("tokens/{provider}")]
+  [Authorize]
+  public async Task<IActionResult> DisconnectProvider(string provider)
+  {
+    if (!MusicProviders.TryNormalize(provider, out var normalizedProvider))
+    {
+      return BadRequest(new { error = $"Provider '{provider}' is not supported." });
+    }
+
+    try
+    {
+      var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+      if (userIdClaim == null || !Guid.TryParse(userIdClaim, out var userId))
+      {
+        return Unauthorized(new { error = "User ID not found in token." });
+      }
+
+      var user = await _userService.GetUserBySupabaseIdAsync(userId);
+      if (user == null)
+      {
+        return NotFound(new { error = "User not found." });
+      }
+
+      await _musicTokenService.RevokeTokensAsync(user.Id, normalizedProvider);
+
+      _logger.LogInformation("Disconnected {Provider} for user {UserId}", normalizedProvider, user.Id);
+      return Ok(new { success = true });
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error disconnecting {Provider}", normalizedProvider);
+      return StatusCode(500, new { error = $"Failed to disconnect {normalizedProvider}" });
+    }
+  }
+
+  /// <summary>
   /// Returns the MusicKit developer token so the frontend can configure MusicKit JS and
   /// start Apple Music user authorization. The token is an app credential (not per-user
   /// secret) but is only needed inside the authenticated dashboard, so it stays gated.
@@ -243,7 +286,12 @@ public class AuthController : ControllerBase
         var user = await _userService.GetUserBySupabaseIdAsync(userId);
         if (user != null)
         {
-          await _musicTokenService.RevokeTokensAsync(user.Id, "spotify");
+          // Every provider, not a hardcoded list — this path previously only revoked
+          // Spotify and silently left Apple Music connected on shared devices.
+          foreach (var provider in MusicProviders.All)
+          {
+            await _musicTokenService.RevokeTokensAsync(user.Id, provider);
+          }
           tokensRevoked = true;
           _logger.LogInformation("Revoked music tokens for user {UserId} (explicit request)", user.Id);
         }

--- a/api/Models/Domain/MusicProviders.cs
+++ b/api/Models/Domain/MusicProviders.cs
@@ -11,6 +11,12 @@ public static class MusicProviders
     [AppleMusic] = AppleMusic
   };
 
+  /// <summary>
+  /// Every supported canonical provider key. For callers that act across providers (e.g.
+  /// revoking all connections on logout) so they can't silently miss one added later.
+  /// </summary>
+  public static IReadOnlyCollection<string> All { get; } = SupportedProviders.Values.Distinct().ToArray();
+
   // Providers whose credentials can be renewed without user interaction. Apple Music is
   // absent by design: a Music User Token has no refresh flow and no expiry signal, so its
   // stored ExpiresAt is an assumed lifetime rather than an authority.

--- a/api/Services/Implementations/SyncSchedulerService.cs
+++ b/api/Services/Implementations/SyncSchedulerService.cs
@@ -32,20 +32,49 @@ public class SyncSchedulerService : ISyncSchedulerService
         _logger.LogInformation("Initializing scheduled sync jobs");
 
         // Schedule main sync job to run daily at 00:01 (12:01 AM)
-        _recurringJobManager.AddOrUpdate(
+        TryScheduleRecurringJob(
             "playlist-sync-processor",
-            () => ProcessScheduledSyncsAsync(),
-            "1 0 * * *" // Daily at 00:01
-        );
+            () => _recurringJobManager.AddOrUpdate(
+                "playlist-sync-processor",
+                () => ProcessScheduledSyncsAsync(),
+                "1 0 * * *" // Daily at 00:01
+            ));
 
         // Schedule subscription validation job daily at 02:00
-        _recurringJobManager.AddOrUpdate(
+        TryScheduleRecurringJob(
             "subscription-validator",
-            () => ValidateSubscriptionsAsync(),
-            "0 2 * * *" // Daily at 2 AM
-        );
+            () => _recurringJobManager.AddOrUpdate(
+                "subscription-validator",
+                () => ValidateSubscriptionsAsync(),
+                "0 2 * * *" // Daily at 2 AM
+            ));
 
         _logger.LogInformation("Scheduled sync jobs initialized");
+    }
+
+    /// <summary>
+    /// Registration runs during startup, is idempotent, and the job definitions persist in
+    /// Hangfire storage across restarts — so a failure here must never take the API down.
+    /// The known offender: an API instance killed while holding Hangfire's distributed lock
+    /// for a recurring job leaves the lock row orphaned, and until Hangfire's staleness
+    /// cutoff (DistributedLockTimeout, 10 minutes) passes, every AddOrUpdate for that job
+    /// times out. Previously that surfaced as an unhandled exception in Program and a crash
+    /// loop. Already-registered jobs keep firing on their stored schedule; the next restart
+    /// retries registration.
+    /// </summary>
+    private void TryScheduleRecurringJob(string jobId, Action register)
+    {
+        try
+        {
+            register();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to register recurring job {JobId}; continuing startup. A previously " +
+                "stored schedule for this job keeps firing, and registration is retried on the " +
+                "next restart", jobId);
+        }
     }
 
     public async Task ProcessScheduledSyncsAsync()

--- a/web/src/app/components/ProviderConnectionStatus.tsx
+++ b/web/src/app/components/ProviderConnectionStatus.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { ClientDate } from '@/components/ui/ClientDate';
 import {
   ConnectionStatus,
+  disconnectProvider,
   getConnectionStatus,
   MusicProvider,
   storeProviderTokens,
@@ -55,6 +56,7 @@ export function ProviderConnectionStatus({
     Partial<ConnectionStatus> & { loading: boolean; error?: string }
   >({ connected: false, canRefresh: false, loading: true });
   const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
 
   const checkStatus = useCallback(async () => {
     try {
@@ -114,6 +116,32 @@ export function ProviderConnectionStatus({
       }));
     } finally {
       setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await disconnectProvider(provider);
+      if (isApple) {
+        try {
+          // Drop the browser-side MusicKit grant too, or the next authorize() silently
+          // reissues a token without the consent popup. Best-effort: the stored tokens are
+          // already gone, and full revocation lives in Apple's settings regardless.
+          await musicKit.unauthorize();
+        } catch (error) {
+          console.error('MusicKit unauthorize failed after disconnect:', error);
+        }
+      }
+      await checkStatus();
+    } catch (error) {
+      console.error(`Failed to disconnect ${provider}:`, error);
+      setStatus((prev) => ({
+        ...prev,
+        error: `Failed to disconnect ${label}. Please try again.`,
+      }));
+    } finally {
+      setDisconnecting(false);
     }
   };
 
@@ -191,14 +219,25 @@ export function ProviderConnectionStatus({
           </button>
         )}
 
-        {needsReconnect && (
-          <button
-            onClick={handleConnect}
-            disabled={connectDisabled}
-            className="px-4 py-2 bg-muted text-muted-foreground rounded-md hover:bg-accent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring text-sm font-medium disabled:opacity-50"
-          >
-            Reconnect
-          </button>
+        {status.connected && (
+          <div className="flex gap-2">
+            {needsReconnect && (
+              <button
+                onClick={handleConnect}
+                disabled={connectDisabled}
+                className="px-4 py-2 bg-muted text-muted-foreground rounded-md hover:bg-accent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring text-sm font-medium disabled:opacity-50"
+              >
+                Reconnect
+              </button>
+            )}
+            <button
+              onClick={handleDisconnect}
+              disabled={disconnecting}
+              className="px-4 py-2 text-muted-foreground rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring text-sm font-medium disabled:opacity-50"
+            >
+              {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+            </button>
+          </div>
         )}
       </div>
 

--- a/web/src/app/components/__tests__/ProviderConnectionStatus.test.tsx
+++ b/web/src/app/components/__tests__/ProviderConnectionStatus.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { ProviderConnectionStatus } from '../ProviderConnectionStatus';
 import {
+  disconnectProvider,
   getConnectionStatus,
   storeProviderTokens,
 } from '../../services/api';
@@ -12,6 +13,7 @@ import { signInWithSpotify } from '../../auth/actions';
 vi.mock('../../services/api', () => ({
   getConnectionStatus: vi.fn(),
   storeProviderTokens: vi.fn(),
+  disconnectProvider: vi.fn(),
 }));
 
 // Server action — invoked directly so a signed-in user isn't bounced off /auth.
@@ -29,14 +31,17 @@ vi.mock('@/components/ui/ClientDate', () => ({
 
 describe('ProviderConnectionStatus', () => {
   let mockAuthorize: Mock;
+  let mockUnauthorize: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuthorize = vi.fn().mockResolvedValue('mut-token');
+    mockUnauthorize = vi.fn().mockResolvedValue(undefined);
     (useMusicKit as Mock).mockReturnValue({
       ready: true,
       error: null,
       authorize: mockAuthorize,
+      unauthorize: mockUnauthorize,
     });
   });
 
@@ -237,5 +242,81 @@ describe('ProviderConnectionStatus', () => {
     // would bounce back without doing anything.
     await user.click(screen.getByText('Reconnect'));
     expect(signInWithSpotify).toHaveBeenCalledOnce();
+  });
+
+  it('disconnects Spotify: deletes stored tokens and refreshes the card', async () => {
+    (getConnectionStatus as Mock)
+      .mockResolvedValueOnce(connectedStatus())
+      .mockResolvedValueOnce(connectedStatus({ connected: false }));
+    (disconnectProvider as Mock).mockResolvedValue({ success: true });
+    const user = userEvent.setup();
+
+    render(<ProviderConnectionStatus provider="spotify" />);
+    await waitFor(() =>
+      expect(screen.getByText('Spotify Connected')).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: /disconnect/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Spotify Not Connected')).toBeInTheDocument()
+    );
+    expect(disconnectProvider).toHaveBeenCalledWith('spotify');
+    // MusicKit is an Apple-only concern.
+    expect(mockUnauthorize).not.toHaveBeenCalled();
+  });
+
+  it('disconnecting Apple Music also drops the browser-side MusicKit grant', async () => {
+    // Without unauthorize(), the next authorize() silently reissues a Music User Token
+    // with no consent popup — "disconnected" in our DB but not in the browser.
+    const farExpiry = new Date(Date.now() + 100 * 24 * 3600 * 1000).toISOString();
+    (getConnectionStatus as Mock)
+      .mockResolvedValueOnce(
+        connectedStatus({
+          provider: 'apple_music',
+          connected: true,
+          canRefresh: false,
+          expiresAt: farExpiry,
+        })
+      )
+      .mockResolvedValueOnce(
+        connectedStatus({ provider: 'apple_music', connected: false })
+      );
+    (disconnectProvider as Mock).mockResolvedValue({ success: true });
+    const user = userEvent.setup();
+
+    render(<ProviderConnectionStatus provider="apple_music" />);
+    await waitFor(() =>
+      expect(screen.getByText('Apple Music Connected')).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: /disconnect/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Apple Music Not Connected')).toBeInTheDocument()
+    );
+    expect(disconnectProvider).toHaveBeenCalledWith('apple_music');
+    expect(mockUnauthorize).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces a failed disconnect and stays connected', async () => {
+    (getConnectionStatus as Mock).mockResolvedValue(connectedStatus());
+    (disconnectProvider as Mock).mockRejectedValue(
+      new Error('API Error: 500 Internal Server Error')
+    );
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const user = userEvent.setup();
+
+    render(<ProviderConnectionStatus provider="spotify" />);
+    await waitFor(() =>
+      expect(screen.getByText('Spotify Connected')).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: /disconnect/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveTextContent(/failed to disconnect spotify/i);
+    expect(screen.getByText('Spotify Connected')).toBeInTheDocument();
+    consoleSpy.mockRestore();
   });
 });

--- a/web/src/app/hooks/__tests__/useMusicKit.test.ts
+++ b/web/src/app/hooks/__tests__/useMusicKit.test.ts
@@ -57,6 +57,32 @@ describe('useMusicKit', () => {
     expect(mockAuthorize).toHaveBeenCalledOnce();
   });
 
+  it('unauthorize drops the grant via the MusicKit instance', async () => {
+    const mockInstanceUnauthorize = vi.fn().mockResolvedValue(undefined);
+    mockConfigure.mockResolvedValue({
+      authorize: mockAuthorize,
+      unauthorize: mockInstanceUnauthorize,
+      isAuthorized: true,
+    });
+
+    const { result } = renderHook(() => useMusicKit());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    await result.current.unauthorize();
+
+    expect(mockInstanceUnauthorize).toHaveBeenCalledOnce();
+  });
+
+  it('unauthorize is a no-op while MusicKit is not ready', async () => {
+    // Unlike authorize: with no instance there is no browser-side grant to drop, and the
+    // caller's server-side disconnect already succeeded — nothing to fail over.
+    (getMusicKitDeveloperToken as Mock).mockReturnValue(new Promise(() => undefined));
+
+    const { result } = renderHook(() => useMusicKit());
+
+    await expect(result.current.unauthorize()).resolves.toBeUndefined();
+  });
+
   it('authorize throws while MusicKit is not ready', async () => {
     // Keep the hook stuck in setup by never resolving the dev-token request.
     (getMusicKitDeveloperToken as Mock).mockReturnValue(new Promise(() => undefined));

--- a/web/src/app/hooks/useMusicKit.ts
+++ b/web/src/app/hooks/useMusicKit.ts
@@ -126,5 +126,13 @@ export function useMusicKit({ enabled = true }: { enabled?: boolean } = {}) {
     return instanceRef.current.authorize();
   }, []);
 
-  return { ready, error, authorize };
+  const unauthorize = useCallback(async (): Promise<void> => {
+    // Best-effort, unlike authorize: with MusicKit unavailable there is no browser-side
+    // grant to drop, and the caller's server-side disconnect already succeeded — the user
+    // can always sever the grant fully from Apple's settings.
+    if (!instanceRef.current) return;
+    await instanceRef.current.unauthorize();
+  }, []);
+
+  return { ready, error, authorize, unauthorize };
 }

--- a/web/src/app/services/api.ts
+++ b/web/src/app/services/api.ts
@@ -260,6 +260,15 @@ export const storeProviderTokens = (
     body: JSON.stringify({ accessToken, refreshToken: refreshToken ?? null }),
   });
 
+// Deletes the tokens stored for the provider. The credential itself can only be revoked
+// provider-side (Spotify account page / Apple settings) — the API has no way to do that.
+export const disconnectProvider = (
+  provider: MusicProvider
+): Promise<{ success: boolean }> =>
+  fetchWithSupabaseAuth(`${API_BASE_URL}/auth/tokens/${provider}`, {
+    method: 'DELETE',
+  });
+
 export const getMusicKitDeveloperToken = (): Promise<{ token: string }> =>
   fetchWithSupabaseAuth(`${API_BASE_URL}/auth/musickit/devtoken`);
 


### PR DESCRIPTION
## Summary

Closes the gap found during #61's E2E: users had no way to disconnect a music provider.

- **`DELETE /api/auth/tokens/{provider}`** — deletes the stored tokens for the authenticated user. Idempotent; unsupported providers 400.
- **Disconnect button** on both provider connection cards. For Apple Music it also calls MusicKit's `unauthorize()` to drop the browser-side grant — without that, the next `authorize()` silently reissues a Music User Token with no consent popup, leaving the account "disconnected" in our DB but not in the browser. `unauthorize()` is best-effort (no-op if MusicKit never initialized).
- **Logout fix** — `POST /api/auth/logout?revokeTokens=true` hardcoded `"spotify"`, silently leaving Apple Music connected on shared devices. It now iterates a new `MusicProviders.All`, so future providers can't be missed either.
- **Startup hardening (found the hard way)** — an API instance killed while holding Hangfire's distributed lock for a recurring job leaves the lock row orphaned; until Hangfire's 10-minute staleness cutoff passes, `AddOrUpdate` for that job times out, and `SyncSchedulerService.InitializeScheduledJobs` let that escape as an unhandled exception — crash-looping the API on any quick restart. Registration is idempotent and the definitions persist in Hangfire storage, so it now catches per job, logs loudly, and continues; stored schedules keep firing and the next restart retries.

## What "disconnect" can and can't do

Neither provider supports revoking the credential server-side: Spotify has no OAuth revocation endpoint (users remove the app at spotify.com/account/apps) and Apple Music User Tokens are managed in Apple's settings. Disconnect therefore deletes our stored copy (plus the MusicKit browser grant for Apple); full revocation remains provider-side.

## Stacked on #61

Base is `claude/apple-music-integration-314qnb` — the provider cards and MusicKit hook this builds on don't exist on `main`. Retarget to `main` after #61 merges (GitHub does this automatically if the branch is deleted on merge).

## Verification

- ✅ 569 backend unit tests (+3 disconnect: revokes, normalizes the provider key, rejects unsupported providers — the logout test now pins revocation of *both* providers; +2 scheduler: both jobs register, and a registration failure neither escapes nor stops the remaining jobs)
- ✅ 82 frontend tests (+5: Spotify disconnect refreshes the card, Apple disconnect calls `unauthorize()`, failed disconnect surfaces an error and stays connected, hook `unauthorize` happy path + not-ready no-op)
- ✅ `tsc --noEmit`, `nx build web`, `dotnet build`
- ✅ Manual E2E on the local stack: disconnected and reconnected both providers from the dashboard
