### PR TITLE
fix(api): make Stripe webhook processing reliable and recoverable

### DIFF
--- a/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
+++ b/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
@@ -7,6 +7,7 @@ using RadioWash.Api.Controllers;
 using RadioWash.Api.Infrastructure.Data;
 using RadioWash.Api.Models.Domain;
 using RadioWash.Api.Models.DTO;
+using RadioWash.Api.Services.Exceptions;
 using RadioWash.Api.Services.Interfaces;
 using System.Security.Claims;
 using Xunit;
@@ -260,11 +261,11 @@ public class SubscriptionControllerTests : IDisposable
   }
 
   [Fact]
-  public async Task HandleStripeWebhook_WhenServiceThrows_ShouldReturnBadRequest()
+  public async Task HandleStripeWebhook_WhenServiceThrows_ShouldReturnInternalServerError()
   {
-    // Arrange
-    var payload = "invalid_payload";
-    var signature = "invalid_signature";
+    // Arrange - a generic processing failure must return 500 so Stripe redelivers
+    var payload = "{\"type\": \"invoice.payment_succeeded\"}";
+    var signature = "t=1234567890,v1=abcd1234";
 
     // Setup HTTP context
     var context = new DefaultHttpContext();
@@ -273,14 +274,41 @@ public class SubscriptionControllerTests : IDisposable
     _controller.ControllerContext.HttpContext = context;
 
     _mockPaymentService.Setup(x => x.HandleWebhookAsync(payload, signature))
-        .ThrowsAsync(new Exception("Invalid webhook"));
+        .ThrowsAsync(new Exception("Transient processing failure"));
+
+    // Act
+    var result = await _controller.HandleStripeWebhook();
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+    Assert.Equal("Webhook processing failed", objectResult.Value);
+  }
+
+  [Fact]
+  public async Task HandleStripeWebhook_WithInvalidSignature_ShouldReturnBadRequest()
+  {
+    // Arrange - a signature verification failure is a permanent rejection (400)
+    var payload = "tampered_payload";
+    var signature = "t=1234567890,v1=invalid";
+
+    // Setup HTTP context
+    var context = new DefaultHttpContext();
+    context.Request.Body = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(payload));
+    context.Request.Headers["Stripe-Signature"] = signature;
+    _controller.ControllerContext.HttpContext = context;
+
+    _mockPaymentService.Setup(x => x.HandleWebhookAsync(payload, signature))
+        .ThrowsAsync(new WebhookSignatureVerificationException(
+            "Stripe webhook signature verification failed",
+            new Stripe.StripeException("Signature mismatch")));
 
     // Act
     var result = await _controller.HandleStripeWebhook();
 
     // Assert
     var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
-    Assert.Equal("Webhook processing failed", badRequestResult.Value);
+    Assert.Equal("Invalid Stripe signature", badRequestResult.Value);
   }
 
   private static SubscriptionPlan CreateSubscriptionPlan(int id, string name)

--- a/api.Tests/Unit/Services/DatabaseIdempotencyServiceTests.cs
+++ b/api.Tests/Unit/Services/DatabaseIdempotencyServiceTests.cs
@@ -236,6 +236,85 @@ public class DatabaseIdempotencyServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task TryProcessEventAsync_StaleProcessingRow_TakeoverIsExclusive()
+    {
+        // Arrange - a stale Processing claim (owner crashed 20 minutes ago).
+        var eventId = "evt_stale_race";
+        var eventType = "customer.subscription.updated";
+
+        _dbContext.ProcessedWebhookEvents.Add(new ProcessedWebhookEvent
+        {
+            EventId = eventId,
+            EventType = eventType,
+            ProcessedAt = DateTime.UtcNow.AddMinutes(-20),
+            Status = WebhookEventStatus.Processing,
+            LastAttemptAt = DateTime.UtcNow.AddMinutes(-20),
+            AttemptCount = 1
+        });
+        await _dbContext.SaveChangesAsync();
+
+        using var context1 = new RadioWashDbContext(_dbOptions);
+        using var context2 = new RadioWashDbContext(_dbOptions);
+        using var service1 = new DatabaseIdempotencyService(context1, _mockLogger.Object);
+        using var service2 = new DatabaseIdempotencyService(context2, _mockLogger.Object);
+
+        // Act - both instances race to take over the stale claim
+        var results = await Task.WhenAll(
+            service1.TryProcessEventAsync(eventId, eventType),
+            service2.TryProcessEventAsync(eventId, eventType));
+
+        // Assert - exactly one wins
+        Assert.Equal(1, results.Count(r => r));
+
+        using var verifyContext = new RadioWashDbContext(_dbOptions);
+        var processedEvent = await verifyContext.ProcessedWebhookEvents
+            .FirstOrDefaultAsync(e => e.EventId == eventId);
+        Assert.NotNull(processedEvent);
+        Assert.Equal(WebhookEventStatus.Processing, processedEvent.Status);
+        Assert.Equal(2, processedEvent.AttemptCount);
+    }
+
+    [Fact]
+    public async Task StaleProcessingTakeover_CompareAndSwap_LoserGetsConcurrencyException()
+    {
+        // Arrange - pins the DB-level CAS itself, bypassing the in-process semaphore that
+        // serializes the service-level race. A stale takeover writes Processing -> Processing,
+        // so with Status as the only concurrency token BOTH writers would commit; the
+        // LastAttemptAt token (changed on every claim) is what makes this a real CAS.
+        var eventId = "evt_cas_race";
+        var staleTime = DateTime.UtcNow.AddMinutes(-20);
+
+        _dbContext.ProcessedWebhookEvents.Add(new ProcessedWebhookEvent
+        {
+            EventId = eventId,
+            EventType = "customer.subscription.updated",
+            ProcessedAt = staleTime,
+            Status = WebhookEventStatus.Processing,
+            LastAttemptAt = staleTime,
+            AttemptCount = 1
+        });
+        await _dbContext.SaveChangesAsync();
+
+        using var context1 = new RadioWashDbContext(_dbOptions);
+        using var context2 = new RadioWashDbContext(_dbOptions);
+        var row1 = await context1.ProcessedWebhookEvents.FirstAsync(e => e.EventId == eventId);
+        var row2 = await context2.ProcessedWebhookEvents.FirstAsync(e => e.EventId == eventId);
+
+        // Act - both contexts observed the same stale claim and try to take it over
+        row1.Status = WebhookEventStatus.Processing;
+        row1.LastAttemptAt = DateTime.UtcNow;
+        row1.AttemptCount++;
+        await context1.SaveChangesAsync();
+
+        row2.Status = WebhookEventStatus.Processing;
+        row2.LastAttemptAt = DateTime.UtcNow;
+        row2.AttemptCount++;
+
+        // Assert - the second writer's original values no longer match the row
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => context2.SaveChangesAsync());
+    }
+
+    [Fact]
     public async Task MarkEventSuccessfulAsync_WithExistingEvent_ShouldSetSucceededStatus()
     {
         // Arrange

--- a/api.Tests/Unit/Services/DatabaseIdempotencyServiceTests.cs
+++ b/api.Tests/Unit/Services/DatabaseIdempotencyServiceTests.cs
@@ -12,18 +12,19 @@ namespace RadioWash.Api.Tests.Unit.Services;
 
 public class DatabaseIdempotencyServiceTests : IDisposable
 {
+    private readonly DbContextOptions<RadioWashDbContext> _dbOptions;
     private readonly RadioWashDbContext _dbContext;
     private readonly Mock<ILogger<DatabaseIdempotencyService>> _mockLogger;
     private readonly DatabaseIdempotencyService _idempotencyService;
 
     public DatabaseIdempotencyServiceTests()
     {
-        var options = new DbContextOptionsBuilder<RadioWashDbContext>()
+        _dbOptions = new DbContextOptionsBuilder<RadioWashDbContext>()
             .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
             .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
 
-        _dbContext = new RadioWashDbContext(options);
+        _dbContext = new RadioWashDbContext(_dbOptions);
         _dbContext.Database.EnsureCreated();
 
         _mockLogger = new Mock<ILogger<DatabaseIdempotencyService>>();
@@ -31,7 +32,7 @@ public class DatabaseIdempotencyServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task TryProcessEventAsync_WithNewEvent_ShouldReturnTrueAndCreateRecord()
+    public async Task TryProcessEventAsync_WithNewEvent_ShouldClaimWithProcessingStatus()
     {
         // Arrange
         var eventId = "evt_new_event";
@@ -47,25 +48,124 @@ public class DatabaseIdempotencyServiceTests : IDisposable
             .FirstOrDefaultAsync(e => e.EventId == eventId);
         Assert.NotNull(processedEvent);
         Assert.Equal(eventType, processedEvent.EventType);
-        Assert.False(processedEvent.IsSuccessful);
+        Assert.Equal(WebhookEventStatus.Processing, processedEvent.Status);
+        Assert.Equal(1, processedEvent.AttemptCount);
+        Assert.NotNull(processedEvent.LastAttemptAt);
         Assert.Null(processedEvent.ErrorMessage);
     }
 
     [Fact]
-    public async Task TryProcessEventAsync_WithExistingEvent_ShouldReturnFalse()
+    public async Task TryProcessEventAsync_WithRecentProcessingClaim_ShouldReturnFalse()
     {
-        // Arrange
+        // Arrange - first call leaves a fresh Processing claim
         var eventId = "evt_existing_event";
         var eventType = "customer.subscription.updated";
 
-        // First call should create the record
         await _idempotencyService.TryProcessEventAsync(eventId, eventType);
 
-        // Act - Second call with same event ID
+        // Act - second call while the claim is live
         var result = await _idempotencyService.TryProcessEventAsync(eventId, eventType);
 
         // Assert
         Assert.False(result);
+    }
+
+    [Fact]
+    public async Task TryProcessEventAsync_WithSucceededEvent_ShouldReturnFalse()
+    {
+        // Arrange
+        var eventId = "evt_succeeded";
+        var eventType = "customer.subscription.updated";
+
+        await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+        await _idempotencyService.MarkEventSuccessfulAsync(eventId);
+
+        // Act
+        var result = await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+
+        // Assert - Succeeded is terminal
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task TryProcessEventAsync_WithFailedEvent_ShouldReClaim()
+    {
+        // Arrange - a failed attempt releases the claim
+        var eventId = "evt_failed_reclaim";
+        var eventType = "customer.subscription.updated";
+
+        await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+        await _idempotencyService.MarkEventFailedAsync(eventId, "transient error");
+
+        // Act - a redelivery/retry can claim the event again
+        var result = await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+
+        // Assert
+        Assert.True(result);
+
+        var processedEvent = await _dbContext.ProcessedWebhookEvents
+            .FirstOrDefaultAsync(e => e.EventId == eventId);
+        Assert.NotNull(processedEvent);
+        Assert.Equal(WebhookEventStatus.Processing, processedEvent.Status);
+        Assert.Equal(2, processedEvent.AttemptCount);
+    }
+
+    [Fact]
+    public async Task TryProcessEventAsync_WithFreshProcessingRow_ShouldReturnFalse()
+    {
+        // Arrange - a Processing row with a recent LastAttemptAt is owned by a live handler
+        var eventId = "evt_fresh_processing";
+        var eventType = "customer.subscription.updated";
+
+        _dbContext.ProcessedWebhookEvents.Add(new ProcessedWebhookEvent
+        {
+            EventId = eventId,
+            EventType = eventType,
+            ProcessedAt = DateTime.UtcNow.AddMinutes(-5),
+            Status = WebhookEventStatus.Processing,
+            LastAttemptAt = DateTime.UtcNow.AddMinutes(-5),
+            AttemptCount = 1
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task TryProcessEventAsync_WithStaleProcessingRow_ShouldTakeOverClaim()
+    {
+        // Arrange - a Processing claim older than 15 minutes is treated as abandoned
+        var eventId = "evt_stale_processing";
+        var eventType = "customer.subscription.updated";
+        var staleTimestamp = DateTime.UtcNow.AddMinutes(-20);
+
+        _dbContext.ProcessedWebhookEvents.Add(new ProcessedWebhookEvent
+        {
+            EventId = eventId,
+            EventType = eventType,
+            ProcessedAt = staleTimestamp,
+            Status = WebhookEventStatus.Processing,
+            LastAttemptAt = staleTimestamp,
+            AttemptCount = 1
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+
+        // Assert - stale claim taken over
+        Assert.True(result);
+
+        var processedEvent = await _dbContext.ProcessedWebhookEvents
+            .FirstOrDefaultAsync(e => e.EventId == eventId);
+        Assert.NotNull(processedEvent);
+        Assert.Equal(WebhookEventStatus.Processing, processedEvent.Status);
+        Assert.Equal(2, processedEvent.AttemptCount);
+        Assert.True(processedEvent.LastAttemptAt > staleTimestamp);
     }
 
     [Fact]
@@ -93,7 +193,50 @@ public class DatabaseIdempotencyServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task MarkEventSuccessfulAsync_WithExistingEvent_ShouldUpdateSuccessFlag()
+    public async Task TryProcessEventAsync_ConcurrentTakeoverOfFailedRow_ShouldOnlyAllowOneToWin()
+    {
+        // Arrange - a Failed row visible to two independent service instances, each with its
+        // own DbContext (simulating two app instances). Status is a concurrency token, so at
+        // most one compare-and-swap to Processing can commit.
+        var eventId = "evt_takeover_race";
+        var eventType = "customer.subscription.updated";
+
+        _dbContext.ProcessedWebhookEvents.Add(new ProcessedWebhookEvent
+        {
+            EventId = eventId,
+            EventType = eventType,
+            ProcessedAt = DateTime.UtcNow.AddMinutes(-2),
+            Status = WebhookEventStatus.Failed,
+            LastAttemptAt = DateTime.UtcNow.AddMinutes(-2),
+            AttemptCount = 1,
+            ErrorMessage = "previous failure"
+        });
+        await _dbContext.SaveChangesAsync();
+
+        using var context1 = new RadioWashDbContext(_dbOptions);
+        using var context2 = new RadioWashDbContext(_dbOptions);
+        using var service1 = new DatabaseIdempotencyService(context1, _mockLogger.Object);
+        using var service2 = new DatabaseIdempotencyService(context2, _mockLogger.Object);
+
+        // Act - both instances race to re-claim the failed event
+        var results = await Task.WhenAll(
+            service1.TryProcessEventAsync(eventId, eventType),
+            service2.TryProcessEventAsync(eventId, eventType));
+
+        // Assert - exactly one wins; the loser either hit the concurrency token conflict or
+        // observed the winner's fresh Processing claim.
+        Assert.Equal(1, results.Count(r => r));
+
+        using var verifyContext = new RadioWashDbContext(_dbOptions);
+        var processedEvent = await verifyContext.ProcessedWebhookEvents
+            .FirstOrDefaultAsync(e => e.EventId == eventId);
+        Assert.NotNull(processedEvent);
+        Assert.Equal(WebhookEventStatus.Processing, processedEvent.Status);
+        Assert.Equal(2, processedEvent.AttemptCount);
+    }
+
+    [Fact]
+    public async Task MarkEventSuccessfulAsync_WithExistingEvent_ShouldSetSucceededStatus()
     {
         // Arrange
         var eventId = "evt_mark_success";
@@ -108,12 +251,34 @@ public class DatabaseIdempotencyServiceTests : IDisposable
         var processedEvent = await _dbContext.ProcessedWebhookEvents
             .FirstOrDefaultAsync(e => e.EventId == eventId);
         Assert.NotNull(processedEvent);
-        Assert.True(processedEvent.IsSuccessful);
+        Assert.Equal(WebhookEventStatus.Succeeded, processedEvent.Status);
         Assert.Null(processedEvent.ErrorMessage);
     }
 
     [Fact]
-    public async Task MarkEventFailedAsync_WithExistingEvent_ShouldUpdateFailureFlagAndMessage()
+    public async Task MarkEventSuccessfulAsync_AfterPriorFailure_ShouldClearErrorMessage()
+    {
+        // Arrange - fail once, re-claim, then succeed
+        var eventId = "evt_success_after_failure";
+        var eventType = "customer.subscription.updated";
+
+        await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+        await _idempotencyService.MarkEventFailedAsync(eventId, "first attempt failed");
+        await _idempotencyService.TryProcessEventAsync(eventId, eventType);
+
+        // Act
+        await _idempotencyService.MarkEventSuccessfulAsync(eventId);
+
+        // Assert
+        var processedEvent = await _dbContext.ProcessedWebhookEvents
+            .FirstOrDefaultAsync(e => e.EventId == eventId);
+        Assert.NotNull(processedEvent);
+        Assert.Equal(WebhookEventStatus.Succeeded, processedEvent.Status);
+        Assert.Null(processedEvent.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task MarkEventFailedAsync_WithExistingEvent_ShouldSetFailedStatusAndMessage()
     {
         // Arrange
         var eventId = "evt_mark_failed";
@@ -122,6 +287,9 @@ public class DatabaseIdempotencyServiceTests : IDisposable
 
         await _idempotencyService.TryProcessEventAsync(eventId, eventType);
 
+        var claimedAt = (await _dbContext.ProcessedWebhookEvents
+            .FirstAsync(e => e.EventId == eventId)).LastAttemptAt;
+
         // Act
         await _idempotencyService.MarkEventFailedAsync(eventId, errorMessage);
 
@@ -129,8 +297,10 @@ public class DatabaseIdempotencyServiceTests : IDisposable
         var processedEvent = await _dbContext.ProcessedWebhookEvents
             .FirstOrDefaultAsync(e => e.EventId == eventId);
         Assert.NotNull(processedEvent);
-        Assert.False(processedEvent.IsSuccessful);
+        Assert.Equal(WebhookEventStatus.Failed, processedEvent.Status);
         Assert.Equal(errorMessage, processedEvent.ErrorMessage);
+        Assert.NotNull(processedEvent.LastAttemptAt);
+        Assert.True(processedEvent.LastAttemptAt >= claimedAt);
     }
 
     [Fact]
@@ -177,19 +347,21 @@ public class DatabaseIdempotencyServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task TryProcessEventAsync_WithPreExistingDatabaseRecord_ShouldReturnFalse()
+    public async Task TryProcessEventAsync_WithPreExistingSucceededRecord_ShouldReturnFalse()
     {
         // Arrange
         var eventId = "evt_pre_existing";
         var eventType = "customer.subscription.updated";
 
-        // Manually insert a record to simulate pre-existing event
+        // Manually insert a record to simulate a previously completed event
         var existingEvent = new ProcessedWebhookEvent
         {
             EventId = eventId,
             EventType = eventType,
             ProcessedAt = DateTime.UtcNow.AddMinutes(-5),
-            IsSuccessful = true
+            Status = WebhookEventStatus.Succeeded,
+            LastAttemptAt = DateTime.UtcNow.AddMinutes(-5),
+            AttemptCount = 1
         };
         _dbContext.ProcessedWebhookEvents.Add(existingEvent);
         await _dbContext.SaveChangesAsync();

--- a/api.Tests/Unit/Services/StripePaymentServiceTests.cs
+++ b/api.Tests/Unit/Services/StripePaymentServiceTests.cs
@@ -1,63 +1,49 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.InMemory;
 using Moq;
 using Stripe;
+using RadioWash.Api.Services.Exceptions;
 using RadioWash.Api.Services.Implementations;
 using RadioWash.Api.Services.Interfaces;
-using RadioWash.Api.Models.Domain;
-using RadioWash.Api.Infrastructure.Data;
 using Xunit;
 
 namespace RadioWash.Api.Tests.Unit.Services;
 
-public class StripePaymentServiceTests : IDisposable
+/// <summary>
+/// Tests HandleWebhookAsync orchestration: signature verification, idempotency claiming,
+/// processor dispatch, success/failure marking, and retry scheduling. Per-event-type
+/// dispatch behavior is covered by the StripeWebhookProcessor tests.
+/// </summary>
+public class StripePaymentServiceTests
 {
+  private const string Payload = "{\"id\":\"evt_test\"}";
+  private const string Signature = "test_signature";
+  private const string WebhookSecret = "whsec_123";
+
   private readonly Mock<IConfiguration> _mockConfiguration;
-  private readonly Mock<ISubscriptionService> _mockSubscriptionService;
   private readonly Mock<IEventUtility> _mockEventUtility;
-  private readonly Mock<CustomerService> _mockCustomerService;
   private readonly Mock<IIdempotencyService> _mockIdempotencyService;
   private readonly Mock<IWebhookRetryService> _mockWebhookRetryService;
   private readonly Mock<IWebhookProcessor> _mockWebhookProcessor;
   private readonly Mock<ILogger<StripePaymentService>> _mockLogger;
-  private readonly RadioWashDbContext _dbContext;
   private readonly StripePaymentService _stripePaymentService;
 
   public StripePaymentServiceTests()
   {
     _mockConfiguration = new Mock<IConfiguration>();
-    _mockSubscriptionService = new Mock<ISubscriptionService>();
     _mockEventUtility = new Mock<IEventUtility>();
-    _mockCustomerService = new Mock<CustomerService>();
     _mockIdempotencyService = new Mock<IIdempotencyService>();
     _mockWebhookRetryService = new Mock<IWebhookRetryService>();
     _mockWebhookProcessor = new Mock<IWebhookProcessor>();
     _mockLogger = new Mock<ILogger<StripePaymentService>>();
 
-    // Setup in-memory database with transaction warnings suppressed
-    var options = new DbContextOptionsBuilder<RadioWashDbContext>()
-        .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-        .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-        .Options;
-    _dbContext = new RadioWashDbContext(options);
-    
-    // Ensure database schema is created for new webhook event table
-    _dbContext.Database.EnsureCreated();
-
-    // Setup configuration
     _mockConfiguration.Setup(x => x["Stripe:SecretKey"]).Returns("sk_test_123");
-    _mockConfiguration.Setup(x => x["Stripe:WebhookSecret"]).Returns("whsec_123");
+    _mockConfiguration.Setup(x => x["Stripe:WebhookSecret"]).Returns(WebhookSecret);
     _mockConfiguration.Setup(x => x["FrontendUrl"]).Returns("https://example.com");
 
     _stripePaymentService = new StripePaymentService(
         _mockConfiguration.Object,
-        _mockSubscriptionService.Object,
         _mockEventUtility.Object,
-        _dbContext,
-        _mockCustomerService.Object,
         _mockIdempotencyService.Object,
         _mockWebhookRetryService.Object,
         _mockWebhookProcessor.Object,
@@ -65,667 +51,277 @@ public class StripePaymentServiceTests : IDisposable
     );
   }
 
-  #region Subscription Updated Tests
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithSubscriptionUpdated_ShouldUpdateSubscriptionWithItemDates()
+  private Event SetupVerifiedEvent(string eventId, string eventType)
   {
-    // Arrange
-    var subscriptionId = "sub_123";
-    var eventId = "evt_test_123";
-    var periodStart = DateTime.UtcNow.AddDays(-30);
-    var periodEnd = DateTime.UtcNow.AddDays(30);
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook(
-        subscriptionId, "active", periodStart, periodEnd);
-
-    SetupEventUtilityMock(webhookPayload, "customer.subscription.updated", subscriptionId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
+    var stripeEvent = new Event { Id = eventId, Type = eventType };
+    _mockEventUtility.Setup(x => x.ConstructEvent(Payload, Signature, WebhookSecret))
+        .Returns(stripeEvent);
+    return stripeEvent;
   }
 
-  [Fact]
-  public async Task HandleWebhookAsync_WithSubscriptionUpdatedNoItems_ShouldOnlyUpdateStatus()
-  {
-    // Arrange
-    var subscriptionId = "sub_123";
-    var eventId = "evt_test_no_items";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook(subscriptionId, "active", null, null);
-
-    SetupEventUtilityMockWithEmptyItems(webhookPayload, "customer.subscription.updated", subscriptionId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  #endregion
-
-  #region Subscription Deleted Tests
+  #region Successful Processing
 
   [Fact]
-  public async Task HandleWebhookAsync_WithSubscriptionDeleted_ShouldCancelSubscription()
+  public async Task HandleWebhookAsync_WithValidEvent_ProcessesAndMarksSuccessful()
   {
     // Arrange
-    var subscriptionId = "sub_123";
-    var eventId = "evt_test_deleted";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateSubscriptionDeletedWebhook(subscriptionId);
+    var eventId = "evt_test_success";
+    var eventType = "customer.subscription.updated";
+    var stripeEvent = SetupVerifiedEvent(eventId, eventType);
 
-    SetupEventUtilityMock(webhookPayload, "customer.subscription.deleted", subscriptionId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.deleted"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.deleted"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  #endregion
-
-  #region Payment Failed Tests
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithPaymentFailed_ShouldUpdateSubscriptionToPastDue()
-  {
-    // Arrange
-    var subscriptionId = "sub_123";
-    var invoiceId = "in_123";
-    var eventId = "evt_test_payment_failed";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateInvoicePaymentFailedWebhook(invoiceId, subscriptionId);
-
-    SetupEventUtilityMockForInvoice(webhookPayload, "invoice.payment_failed", invoiceId, subscriptionId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "invoice.payment_failed"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "invoice.payment_failed"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithPaymentFailedNoSubscription_ShouldNotUpdateStatus()
-  {
-    // Arrange
-    var invoiceId = "in_123";
-    var eventId = "evt_test_payment_failed_no_sub";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateInvoicePaymentFailedWebhook(invoiceId, null);
-
-    SetupEventUtilityMockForInvoice(webhookPayload, "invoice.payment_failed", invoiceId, null, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "invoice.payment_failed"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "invoice.payment_failed"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  #endregion
-
-  #region Payment Succeeded Tests
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithPaymentSucceeded_ShouldUpdateSubscriptionToActive()
-  {
-    // Arrange
-    var subscriptionId = "sub_123";
-    var invoiceId = "in_123";
-    var eventId = "evt_test_payment_succeeded";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateInvoicePaymentSucceededWebhook(invoiceId, subscriptionId);
-
-    SetupEventUtilityMockForInvoice(webhookPayload, "invoice.payment_succeeded", invoiceId, subscriptionId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "invoice.payment_succeeded"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "invoice.payment_succeeded"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithPaymentSucceededNoSubscription_ShouldNotUpdateStatus()
-  {
-    // Arrange
-    var invoiceId = "in_123";
-    var eventId = "evt_test_payment_succeeded_no_sub";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateInvoicePaymentSucceededWebhook(invoiceId, null);
-
-    SetupEventUtilityMockForInvoice(webhookPayload, "invoice.payment_succeeded", invoiceId, null, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "invoice.payment_succeeded"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "invoice.payment_succeeded"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  #endregion
-
-  #region Subscription Created Tests
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithSubscriptionCreated_ShouldCreateSubscription()
-  {
-    // Arrange
-    var subscriptionId = "sub_123";
-    var customerId = "cus_123";
-    var priceId = "price_123";
-    var userId = 17;
-    var planId = 1;
-    var eventId = "evt_test_subscription_created";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateSubscriptionCreatedWebhook(
-        subscriptionId, customerId, priceId, userId);
-
-    var mockPlan = CreateMockSubscriptionPlan(planId, priceId);
-    SetupEventUtilityMockForSubscriptionCreated(webhookPayload, subscriptionId, customerId, priceId, userId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.created"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.created"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithSubscriptionCreatedNoPlan_ShouldNotCreateSubscription()
-  {
-    // Arrange
-    var subscriptionId = "sub_123";
-    var customerId = "cus_123";
-    var priceId = "price_unknown";
-    var userId = 17;
-    var eventId = "evt_test_subscription_created_no_plan";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateSubscriptionCreatedWebhook(
-        subscriptionId, customerId, priceId, userId);
-
-    SetupEventUtilityMockForSubscriptionCreated(webhookPayload, subscriptionId, customerId, priceId, userId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.created"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.created"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithSubscriptionCreatedNoItems_ShouldNotCreateSubscription()
-  {
-    // Arrange
-    var subscriptionId = "sub_123";
-    var customerId = "cus_123";
-    var eventId = "evt_test_subscription_created_no_items";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateSubscriptionCreatedWebhookNoItems(subscriptionId, customerId);
-
-    SetupEventUtilityMockForSubscriptionCreatedNoItems(webhookPayload, subscriptionId, customerId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.created"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.created"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  #endregion
-
-  #region Checkout Session Completed Tests
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithCheckoutCompleted_ShouldLogSuccess()
-  {
-    // Arrange
-    var sessionId = "cs_123";
-    var userId = 1;
-    var eventId = "evt_test_checkout_completed";
-    var webhookPayload = StripeWebhookPayloadBuilder.CreateCheckoutSessionCompletedWebhook(sessionId, userId);
-
-    SetupEventUtilityMockForCheckoutCompleted(webhookPayload, sessionId, userId, eventId);
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "checkout.session.completed"))
-        .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
-        .Returns(Task.CompletedTask);
-
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-
-    // Assert
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "checkout.session.completed"), Times.Once);
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
-  }
-
-  #endregion
-
-  #region Unhandled Event Tests
-
-  [Fact]
-  public async Task HandleWebhookAsync_WithUnhandledEventType_ShouldLogUnhandled()
-  {
-    // Arrange
-    var eventType = "customer.created";
-    var eventId = "evt_test_unhandled";
-    var mockEvent = new Event { Id = eventId, Type = eventType };
-    
-    _mockEventUtility.Setup(x => x.ConstructEvent(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-        .Returns(mockEvent);
     _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
         .ReturnsAsync(true);
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync("{}", "test_signature"))
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(stripeEvent))
         .Returns(Task.CompletedTask);
 
     // Act
-    await _stripePaymentService.HandleWebhookAsync("{}", "test_signature");
+    await _stripePaymentService.HandleWebhookAsync(Payload, Signature);
 
     // Assert
     _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, eventType), Times.Once);
+    _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(stripeEvent), Times.Once);
     _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync("{}", "test_signature"), Times.Once);
+    _mockIdempotencyService.Verify(x => x.MarkEventFailedAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
   }
-
-  #endregion
-
-  #region Helper Methods
-
-  private void SetupEventUtilityMock(string payload, string eventType, string subscriptionId, string eventId = null)
-  {
-    var subscription = new Stripe.Subscription { Id = subscriptionId, Status = "active" };
-    
-    // Create subscription items with period dates
-    var subscriptionItem = new SubscriptionItem();
-    var periodStart = DateTime.UtcNow.AddDays(-30);
-    var periodEnd = DateTime.UtcNow.AddDays(30);
-    subscriptionItem.CurrentPeriodStart = periodStart;
-    subscriptionItem.CurrentPeriodEnd = periodEnd;
-    
-    subscription.Items = new StripeList<SubscriptionItem>
-    {
-      Data = new List<SubscriptionItem> { subscriptionItem }
-    };
-
-    var mockEvent = new Event
-    {
-      Id = eventId ?? "evt_test_" + Guid.NewGuid().ToString()[..8],
-      Type = eventType,
-      Data = new Stripe.EventData { Object = subscription }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(payload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-  }
-
-  private void SetupEventUtilityMockWithEmptyItems(string payload, string eventType, string subscriptionId, string eventId = null)
-  {
-    var subscription = new Stripe.Subscription { Id = subscriptionId, Status = "active", Items = null };
-    var mockEvent = new Event
-    {
-      Id = eventId ?? "evt_test_" + Guid.NewGuid().ToString()[..8],
-      Type = eventType,
-      Data = new Stripe.EventData { Object = subscription }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(payload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-  }
-
-  private void SetupEventUtilityMockForInvoice(string payload, string eventType, string invoiceId, string? subscriptionId, string eventId = null)
-  {
-    var invoice = new Invoice { Id = invoiceId };
-    
-    // Mock RawJObject for subscription reference
-    var rawJObject = new Newtonsoft.Json.Linq.JObject();
-    if (!string.IsNullOrEmpty(subscriptionId))
-    {
-      rawJObject["subscription"] = subscriptionId;
-    }
-
-    // Minimal reflection usage for setting RawJObject - unavoidable due to Stripe SDK design
-    var rawJObjectProperty = typeof(StripeEntity).GetProperty("RawJObject", 
-        System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-    rawJObjectProperty?.SetValue(invoice, rawJObject);
-
-    var mockEvent = new Event
-    {
-      Id = eventId ?? "evt_test_" + Guid.NewGuid().ToString()[..8],
-      Type = eventType,
-      Data = new Stripe.EventData { Object = invoice }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(payload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-  }
-
-  private void SetupEventUtilityMockForSubscriptionCreated(string payload, string subscriptionId, string customerId, string priceId, int userId, string eventId = null)
-  {
-    var subscription = new Stripe.Subscription 
-    { 
-      Id = subscriptionId, 
-      CustomerId = customerId,
-      Status = "active"
-    };
-
-    // Create subscription items with price ID
-    var subscriptionItem = new SubscriptionItem();
-    var price = new Price { Id = priceId };
-    subscriptionItem.Price = price;
-    
-    subscription.Items = new StripeList<SubscriptionItem>
-    {
-      Data = new List<SubscriptionItem> { subscriptionItem }
-    };
-
-    // Set subscription metadata with user ID
-    subscription.Metadata = new Dictionary<string, string>
-    {
-      { "userId", userId.ToString() }
-    };
-
-    var mockEvent = new Event
-    {
-      Id = eventId ?? "evt_test_" + Guid.NewGuid().ToString()[..8],
-      Type = "customer.subscription.created",
-      Data = new Stripe.EventData { Object = subscription }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(payload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-  }
-
-  private void SetupEventUtilityMockForSubscriptionCreatedNoItems(string payload, string subscriptionId, string customerId, string eventId = null)
-  {
-    var subscription = new Stripe.Subscription 
-    { 
-      Id = subscriptionId, 
-      CustomerId = customerId,
-      Items = null // No items
-    };
-
-    var mockEvent = new Event
-    {
-      Id = eventId ?? "evt_test_" + Guid.NewGuid().ToString()[..8],
-      Type = "customer.subscription.created",
-      Data = new Stripe.EventData { Object = subscription }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(payload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-  }
-
-  private void SetupEventUtilityMockForCheckoutCompleted(string payload, string sessionId, int userId, string eventId = null)
-  {
-    var session = new Stripe.Checkout.Session 
-    { 
-      Id = sessionId,
-      Metadata = new Dictionary<string, string>
-      {
-        { "userId", userId.ToString() }
-      }
-    };
-
-    var mockEvent = new Event
-    {
-      Id = eventId ?? "evt_test_" + Guid.NewGuid().ToString()[..8],
-      Type = "checkout.session.completed",
-      Data = new Stripe.EventData { Object = session }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(payload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-  }
-
-  private static UserSubscription CreateMockUserSubscription()
-  {
-    return new UserSubscription
-    {
-      Id = 1,
-      UserId = 1,
-      PlanId = 1,
-      StripeSubscriptionId = "sub_123",
-      StripeCustomerId = "cus_123",
-      Status = "active",
-      CreatedAt = DateTime.UtcNow,
-      UpdatedAt = DateTime.UtcNow
-    };
-  }
-
-  private static SubscriptionPlan CreateMockSubscriptionPlan(int planId, string stripePriceId)
-  {
-    return new SubscriptionPlan
-    {
-      Id = planId,
-      Name = "Test Plan",
-      PriceInCents = 500,
-      BillingPeriod = "monthly",
-      StripePriceId = stripePriceId,
-      IsActive = true,
-      CreatedAt = DateTime.UtcNow,
-      UpdatedAt = DateTime.UtcNow
-    };
-  }
-
-  #endregion
-
-  #region Race Condition and Idempotency Tests
 
   [Fact]
-  public async Task HandleWebhookAsync_WithDuplicateEventId_ShouldProcessOnlyOnce()
+  public async Task HandleWebhookAsync_PassesVerifiedEventToProcessor()
   {
     // Arrange
-    var eventId = "evt_test_duplicate";
-    var subscriptionId = "sub_123";
-    var webhookPayload = "test_payload";
+    var eventId = "evt_test_dispatch";
+    var eventType = "invoice.payment_succeeded";
+    SetupVerifiedEvent(eventId, eventType);
 
-    var mockEvent = new Event
-    {
-      Id = eventId,
-      Type = "customer.subscription.updated",
-      Data = new Stripe.EventData 
-      { 
-        Object = new Stripe.Subscription 
-        { 
-          Id = subscriptionId, 
-          Status = "active" 
-        } 
-      }
-    };
+    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
+        .ReturnsAsync(true);
 
-    _mockEventUtility.Setup(x => x.ConstructEvent(webhookPayload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-    
-    // First call should be allowed to process
-    _mockIdempotencyService.SetupSequence(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"))
-        .ReturnsAsync(true)   // First call - allow processing
-        .ReturnsAsync(false); // Second call - already processed
-
-    _mockIdempotencyService.Setup(x => x.MarkEventSuccessfulAsync(eventId))
-        .Returns(Task.CompletedTask);
-    
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"))
+    Event? receivedEvent = null;
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(It.IsAny<Event>()))
+        .Callback<Event>(e => receivedEvent = e)
         .Returns(Task.CompletedTask);
 
-    // Act - Process the webhook twice
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
+    // Act
+    await _stripePaymentService.HandleWebhookAsync(Payload, Signature);
 
-    // Assert - Idempotency service should be called twice, but webhook processor only once
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"), Times.Exactly(2));
-    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
-    _mockWebhookProcessor.Verify(x => x.ProcessWebhookAsync(webhookPayload, "test_signature"), Times.Once);
+    // Assert - the processor receives the event constructed from the verified payload
+    Assert.NotNull(receivedEvent);
+    Assert.Equal(eventId, receivedEvent!.Id);
+    Assert.Equal(eventType, receivedEvent.Type);
   }
 
+  #endregion
+
+  #region Idempotency
+
   [Fact]
-  public async Task HandleWebhookAsync_WhenIdempotencyServiceRejectsDuplicate_ShouldSkipProcessing()
+  public async Task HandleWebhookAsync_WhenIdempotencyClaimDenied_SkipsProcessing()
   {
     // Arrange
     var eventId = "evt_test_already_processed";
-    var subscriptionId = "sub_123";
-    var webhookPayload = "test_payload";
+    var eventType = "customer.subscription.updated";
+    SetupVerifiedEvent(eventId, eventType);
 
-    var mockEvent = new Event
-    {
-      Id = eventId,
-      Type = "customer.subscription.updated",
-      Data = new Stripe.EventData 
-      { 
-        Object = new Stripe.Subscription 
-        { 
-          Id = subscriptionId, 
-          Status = "active" 
-        } 
-      }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(webhookPayload, "test_signature", "whsec_123"))
-        .Returns(mockEvent);
-    
-    // Idempotency service indicates event already processed
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"))
+    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
         .ReturnsAsync(false);
 
-    // Act
-    await _stripePaymentService.HandleWebhookAsync(webhookPayload, "test_signature");
+    // Act - no exception expected
+    await _stripePaymentService.HandleWebhookAsync(Payload, Signature);
 
-    // Assert - No business logic should be executed
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"), Times.Once);
+    // Assert - nothing was processed or marked
+    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, eventType), Times.Once);
+    _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(It.IsAny<Event>()), Times.Never);
     _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(It.IsAny<string>()), Times.Never);
-    _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    _mockIdempotencyService.Verify(x => x.MarkEventFailedAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
   }
 
   [Fact]
-  public async Task HandleWebhookAsync_ProcessingFails_ShouldMarkEventAsFailed()
+  public async Task HandleWebhookAsync_WithDuplicateEventId_ProcessesOnlyOnce()
+  {
+    // Arrange
+    var eventId = "evt_test_duplicate";
+    var eventType = "customer.subscription.updated";
+    SetupVerifiedEvent(eventId, eventType);
+
+    _mockIdempotencyService.SetupSequence(x => x.TryProcessEventAsync(eventId, eventType))
+        .ReturnsAsync(true)   // First delivery - claim granted
+        .ReturnsAsync(false); // Second delivery - already processed
+
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(It.IsAny<Event>()))
+        .Returns(Task.CompletedTask);
+
+    // Act - process the same webhook twice
+    await _stripePaymentService.HandleWebhookAsync(Payload, Signature);
+    await _stripePaymentService.HandleWebhookAsync(Payload, Signature);
+
+    // Assert - claim attempted twice, but processed and marked only once
+    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, eventType), Times.Exactly(2));
+    _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(It.IsAny<Event>()), Times.Once);
+    _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(eventId), Times.Once);
+  }
+
+  #endregion
+
+  #region Processing Failures
+
+  [Fact]
+  public async Task HandleWebhookAsync_WhenProcessorFails_MarksFailedAndRethrows()
   {
     // Arrange
     var eventId = "evt_test_failed";
-    var subscriptionId = "sub_failed";
-    var webhookPayload = "failed_payload";
+    var eventType = "customer.subscription.updated";
     var errorMessage = "Database error";
+    SetupVerifiedEvent(eventId, eventType);
 
-    var mockEvent = new Event
-    {
-      Id = eventId,
-      Type = "customer.subscription.updated",
-      Data = new Stripe.EventData 
-      { 
-        Object = new Stripe.Subscription 
-        { 
-          Id = subscriptionId, 
-          Status = "active" 
-        } 
-      }
-    };
-
-    _mockEventUtility.Setup(x => x.ConstructEvent(webhookPayload, "failed_signature", "whsec_123"))
-        .Returns(mockEvent);
-    
-    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"))
+    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
         .ReturnsAsync(true);
-    
-    _mockIdempotencyService.Setup(x => x.MarkEventFailedAsync(eventId, errorMessage))
-        .Returns(Task.CompletedTask);
-    
-    _mockWebhookProcessor.Setup(x => x.ProcessWebhookAsync(webhookPayload, "failed_signature"))
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(It.IsAny<Event>()))
         .ThrowsAsync(new InvalidOperationException(errorMessage));
+    _mockWebhookRetryService.Setup(x => x.IsRetryableError(It.IsAny<Exception>()))
+        .Returns(false);
 
-    // Act & Assert
-    await Assert.ThrowsAsync<InvalidOperationException>(
-        () => _stripePaymentService.HandleWebhookAsync(webhookPayload, "failed_signature"));
+    // Act & Assert - the original exception propagates, NOT wrapped in
+    // WebhookSignatureVerificationException (which would turn a transient
+    // failure into a permanent 400 rejection)
+    var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
+    Assert.Equal(errorMessage, thrown.Message);
 
-    // Verify that idempotency service was called to mark failure
-    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(eventId, "customer.subscription.updated"), Times.Once);
     _mockIdempotencyService.Verify(x => x.MarkEventFailedAsync(eventId, errorMessage), Times.Once);
     _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(It.IsAny<string>()), Times.Never);
   }
 
+  [Fact]
+  public async Task HandleWebhookAsync_WhenProcessorThrowsStripeException_RethrowsUnwrapped()
+  {
+    // Arrange - a StripeException thrown DURING processing (e.g. an API call inside a
+    // handler) must not be mistaken for a signature verification failure
+    var eventId = "evt_test_stripe_error";
+    var eventType = "invoice.payment_failed";
+    SetupVerifiedEvent(eventId, eventType);
+
+    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
+        .ReturnsAsync(true);
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(It.IsAny<Event>()))
+        .ThrowsAsync(new StripeException("Stripe API unavailable"));
+    _mockWebhookRetryService.Setup(x => x.IsRetryableError(It.IsAny<Exception>()))
+        .Returns(true);
+
+    // Act & Assert - rethrown as StripeException, not WebhookSignatureVerificationException
+    await Assert.ThrowsAsync<StripeException>(
+        () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
+
+    _mockIdempotencyService.Verify(x => x.MarkEventFailedAsync(eventId, "Stripe API unavailable"), Times.Once);
+  }
+
+  [Fact]
+  public async Task HandleWebhookAsync_WithRetryableProcessingError_SchedulesRetry()
+  {
+    // Arrange
+    var eventId = "evt_test_retryable";
+    var eventType = "customer.subscription.updated";
+    var errorMessage = "Transient database timeout";
+    SetupVerifiedEvent(eventId, eventType);
+
+    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
+        .ReturnsAsync(true);
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(It.IsAny<Event>()))
+        .ThrowsAsync(new InvalidOperationException(errorMessage));
+    _mockWebhookRetryService.Setup(x => x.IsRetryableError(It.IsAny<Exception>()))
+        .Returns(true);
+
+    // Act & Assert
+    await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
+
+    _mockWebhookRetryService.Verify(
+        x => x.ScheduleRetryAsync(eventId, eventType, Payload, Signature, errorMessage, 1),
+        Times.Once);
+  }
+
+  [Fact]
+  public async Task HandleWebhookAsync_WithNonRetryableProcessingError_DoesNotScheduleRetry()
+  {
+    // Arrange
+    var eventId = "evt_test_non_retryable";
+    var eventType = "customer.subscription.updated";
+    SetupVerifiedEvent(eventId, eventType);
+
+    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
+        .ReturnsAsync(true);
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(It.IsAny<Event>()))
+        .ThrowsAsync(new InvalidOperationException("Permanent validation failure"));
+    _mockWebhookRetryService.Setup(x => x.IsRetryableError(It.IsAny<Exception>()))
+        .Returns(false);
+
+    // Act & Assert
+    await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
+
+    _mockWebhookRetryService.Verify(
+        x => x.ScheduleRetryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()),
+        Times.Never);
+  }
+
+  [Fact]
+  public async Task HandleWebhookAsync_WhenSchedulingRetryFails_StillRethrowsOriginalException()
+  {
+    // Arrange
+    var eventId = "evt_test_retry_schedule_fails";
+    var eventType = "customer.subscription.updated";
+    var errorMessage = "Original processing error";
+    SetupVerifiedEvent(eventId, eventType);
+
+    _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(eventId, eventType))
+        .ReturnsAsync(true);
+    _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(It.IsAny<Event>()))
+        .ThrowsAsync(new InvalidOperationException(errorMessage));
+    _mockWebhookRetryService.Setup(x => x.IsRetryableError(It.IsAny<Exception>()))
+        .Returns(true);
+    _mockWebhookRetryService.Setup(x => x.ScheduleRetryAsync(It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+        .ThrowsAsync(new Exception("Retry scheduling failed"));
+
+    // Act & Assert - the retry-scheduling failure is swallowed; the original exception wins
+    var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
+    Assert.Equal(errorMessage, thrown.Message);
+  }
+
   #endregion
 
-  public void Dispose()
+  #region Signature Verification and Configuration
+
+  [Fact]
+  public async Task HandleWebhookAsync_WhenSignatureVerificationFails_ThrowsWebhookSignatureVerificationException()
   {
-    _dbContext.Dispose();
+    // Arrange
+    var stripeException = new StripeException("Signature verification failed");
+    _mockEventUtility.Setup(x => x.ConstructEvent(Payload, Signature, WebhookSecret))
+        .Throws(stripeException);
+
+    // Act & Assert
+    var thrown = await Assert.ThrowsAsync<WebhookSignatureVerificationException>(
+        () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
+    Assert.Same(stripeException, thrown.InnerException);
+
+    // Nothing downstream runs for an unauthenticated payload
+    _mockIdempotencyService.Verify(x => x.TryProcessEventAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(It.IsAny<Event>()), Times.Never);
   }
+
+  [Fact]
+  public async Task HandleWebhookAsync_WithMissingWebhookSecret_ThrowsInvalidOperationException()
+  {
+    // Arrange
+    _mockConfiguration.Setup(x => x["Stripe:WebhookSecret"]).Returns((string?)null);
+
+    // Act & Assert
+    await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
+
+    _mockEventUtility.Verify(x => x.ConstructEvent(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+  }
+
+  #endregion
 }

--- a/api.Tests/Unit/Services/StripeSignatureVerificationTests.cs
+++ b/api.Tests/Unit/Services/StripeSignatureVerificationTests.cs
@@ -1,0 +1,122 @@
+using System.Security.Cryptography;
+using System.Text;
+using RadioWash.Api.Services.Implementations;
+using Stripe;
+using Xunit;
+
+namespace RadioWash.Api.Tests.Unit.Services;
+
+/// <summary>
+/// Exercises the REAL Stripe signature verification through EventUtilityWrapper (no mocks).
+/// Documents the security properties the webhook pipeline relies on: authentic payloads
+/// verify, tampered payloads are rejected, and stale timestamps are rejected — which is
+/// exactly why the internal retry path must use ParseEvent instead of re-verifying.
+/// </summary>
+public class StripeSignatureVerificationTests
+{
+  private const string WebhookSecret = "whsec_test_secret_for_signature_tests";
+
+  private readonly EventUtilityWrapper _eventUtility = new();
+
+  /// <summary>
+  /// Builds a minimal event payload whose api_version matches the SDK's expected version,
+  /// so ConstructEvent's default API-version check passes.
+  /// </summary>
+  private static string BuildEventPayload(string eventId = "evt_sig_test", long? created = null)
+  {
+    var createdUnix = created ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+    var apiVersion = StripeConfiguration.ApiVersion;
+
+    return "{"
+        + $"\"id\":\"{eventId}\","
+        + "\"object\":\"event\","
+        + $"\"api_version\":\"{apiVersion}\","
+        + $"\"created\":{createdUnix},"
+        + "\"data\":{\"object\":{\"id\":\"cus_sig_test\",\"object\":\"customer\"}},"
+        + "\"livemode\":false,"
+        + "\"pending_webhooks\":1,"
+        + "\"request\":{\"id\":\"req_sig_test\",\"idempotency_key\":null},"
+        + "\"type\":\"customer.created\""
+        + "}";
+  }
+
+  /// <summary>
+  /// Computes a real Stripe-Signature header: t={unixSeconds},v1={HMACSHA256hex(secret, "{t}.{payload}")}.
+  /// </summary>
+  private static string ComputeSignatureHeader(string payload, string secret, long timestamp)
+  {
+    var signedPayload = $"{timestamp}.{payload}";
+    using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+    var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(signedPayload));
+    var v1 = Convert.ToHexString(hash).ToLowerInvariant();
+    return $"t={timestamp},v1={v1}";
+  }
+
+  [Fact]
+  public void ConstructEvent_WithValidSignatureAndCurrentTimestamp_ReturnsEvent()
+  {
+    // Arrange
+    var payload = BuildEventPayload();
+    var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+    var signature = ComputeSignatureHeader(payload, WebhookSecret, timestamp);
+
+    // Act
+    var stripeEvent = _eventUtility.ConstructEvent(payload, signature, WebhookSecret);
+
+    // Assert
+    Assert.NotNull(stripeEvent);
+    Assert.Equal("evt_sig_test", stripeEvent.Id);
+    Assert.Equal("customer.created", stripeEvent.Type);
+  }
+
+  [Fact]
+  public void ConstructEvent_WithTamperedPayload_ThrowsStripeException()
+  {
+    // Arrange - sign one payload, then verify a different (tampered) one
+    var signedPayload = BuildEventPayload();
+    var tamperedPayload = BuildEventPayload(eventId: "evt_attacker_swap");
+    var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+    var signature = ComputeSignatureHeader(signedPayload, WebhookSecret, timestamp);
+
+    // Act & Assert
+    Assert.Throws<StripeException>(
+        () => _eventUtility.ConstructEvent(tamperedPayload, signature, WebhookSecret));
+  }
+
+  [Fact]
+  public void ConstructEvent_WithStaleTimestamp_ThrowsStripeException()
+  {
+    // Arrange - a correctly-signed payload whose signature timestamp is 600s old, well
+    // outside Stripe's default 300s tolerance.
+    //
+    // This is WHY the internal retry path (WebhookRetryService) must parse the stored
+    // payload WITHOUT re-verifying its signature: by the time a retry runs (minutes to
+    // hours later), the original signature timestamp is guaranteed to be outside the
+    // tolerance window, so re-verification of an already-verified payload would always
+    // fail by design.
+    var staleTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 600;
+    var payload = BuildEventPayload(created: staleTimestamp);
+    var signature = ComputeSignatureHeader(payload, WebhookSecret, staleTimestamp);
+
+    // Act & Assert
+    Assert.Throws<StripeException>(
+        () => _eventUtility.ConstructEvent(payload, signature, WebhookSecret));
+  }
+
+  [Fact]
+  public void ParseEvent_WithOldPayloadAndNoSignature_ReturnsEvent()
+  {
+    // Arrange - an hour-old payload with no signature involved: proves the replay path
+    // used by the retry queue still works long after the signature tolerance has expired
+    var oldTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 3600;
+    var payload = BuildEventPayload(eventId: "evt_replay_test", created: oldTimestamp);
+
+    // Act
+    var stripeEvent = _eventUtility.ParseEvent(payload);
+
+    // Assert
+    Assert.NotNull(stripeEvent);
+    Assert.Equal("evt_replay_test", stripeEvent.Id);
+    Assert.Equal("customer.created", stripeEvent.Type);
+  }
+}

--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -176,12 +176,111 @@ public class SubscriptionServiceTests
   }
 
   [Fact]
-  public async Task UpdateSubscriptionStatusAsync_WithValidSubscription_ShouldUpdateStatus()
+  public async Task UpdateSubscriptionStatusAsync_ActiveToCanceled_UpdatesStatusStampsCanceledAtAndDisablesConfigs()
   {
     // Arrange
+    var userId = 1;
     var stripeSubscriptionId = "sub_123";
-    var newStatus = SubscriptionStatus.Canceled;
-    var subscription = CreateUserSubscription(1);
+    var subscription = CreateUserSubscription(userId);
+    subscription.StripeSubscriptionId = stripeSubscriptionId;
+    var enabledConfig = new PlaylistSyncConfig { Id = 1, UserId = userId, IsActive = true };
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
+        .ReturnsAsync(subscription);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
+        .ReturnsAsync(new[] { enabledConfig });
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()))
+        .Returns(Task.CompletedTask);
+
+    // Act
+    var result = await _subscriptionService.UpdateSubscriptionStatusAsync(stripeSubscriptionId, SubscriptionStatus.Canceled);
+
+    // Assert
+    Assert.NotNull(result);
+    Assert.Equal(SubscriptionStatus.Canceled, result.Status);
+    Assert.NotNull(result.CanceledAt);
+
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.Is<UserSubscription>(
+        s => s.Status == SubscriptionStatus.Canceled)), Times.Once);
+    // Transitioning out of active must disable running sync configs
+    _mockUnitOfWork.Verify(
+        x => x.SyncConfigs.DisableConfigAsync(enabledConfig.Id, AutoDisableReason.SubscriptionInactive),
+        Times.Once);
+  }
+
+  [Fact]
+  public async Task UpdateSubscriptionStatusAsync_ActiveToPastDue_DisablesEnabledConfigs()
+  {
+    // Arrange
+    var userId = 2;
+    var stripeSubscriptionId = "sub_past_due";
+    var subscription = CreateUserSubscription(userId);
+    subscription.StripeSubscriptionId = stripeSubscriptionId;
+    var enabledConfig = new PlaylistSyncConfig { Id = 21, UserId = userId, IsActive = true };
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
+        .ReturnsAsync(subscription);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
+        .ReturnsAsync(new[] { enabledConfig });
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()))
+        .Returns(Task.CompletedTask);
+
+    // Act
+    var result = await _subscriptionService.UpdateSubscriptionStatusAsync(stripeSubscriptionId, SubscriptionStatus.PastDue);
+
+    // Assert
+    Assert.Equal(SubscriptionStatus.PastDue, result.Status);
+    Assert.Null(result.CanceledAt); // only canceled stamps CanceledAt
+    _mockUnitOfWork.Verify(
+        x => x.SyncConfigs.DisableConfigAsync(enabledConfig.Id, AutoDisableReason.SubscriptionInactive),
+        Times.Once);
+  }
+
+  [Fact]
+  public async Task UpdateSubscriptionStatusAsync_CanceledToActive_ReenablesAutoDisabledConfigs()
+  {
+    // Arrange
+    var userId = 3;
+    var stripeSubscriptionId = "sub_reactivated";
+    var subscription = CreateUserSubscription(userId);
+    subscription.StripeSubscriptionId = stripeSubscriptionId;
+    subscription.Status = SubscriptionStatus.Canceled;
+    var autoDisabled = new PlaylistSyncConfig
+    {
+      Id = 31,
+      UserId = userId,
+      IsActive = false,
+      AutoDisabledReason = AutoDisableReason.SubscriptionInactive
+    };
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
+        .ReturnsAsync(subscription);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
+        .ReturnsAsync(new[] { autoDisabled });
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.EnableConfigAsync(It.IsAny<int>()))
+        .Returns(Task.CompletedTask);
+
+    // Act
+    var result = await _subscriptionService.UpdateSubscriptionStatusAsync(stripeSubscriptionId, SubscriptionStatus.Active);
+
+    // Assert
+    Assert.Equal(SubscriptionStatus.Active, result.Status);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.EnableConfigAsync(autoDisabled.Id), Times.Once);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task UpdateSubscriptionStatusAsync_ActiveToActive_DoesNotTouchConfigs()
+  {
+    // Arrange - no entitlement transition means no config side effects
+    var stripeSubscriptionId = "sub_no_transition";
+    var subscription = CreateUserSubscription(4);
     subscription.StripeSubscriptionId = stripeSubscriptionId;
 
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
@@ -190,14 +289,60 @@ public class SubscriptionServiceTests
         .ReturnsAsync((UserSubscription s) => s);
 
     // Act
-    var result = await _subscriptionService.UpdateSubscriptionStatusAsync(stripeSubscriptionId, newStatus);
+    await _subscriptionService.UpdateSubscriptionStatusAsync(stripeSubscriptionId, SubscriptionStatus.Active);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(newStatus, result.Status);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.GetEnabledByUserIdAsync(It.IsAny<int>()), Times.Never);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+  }
 
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.Is<UserSubscription>(
-        s => s.Status == newStatus)), Times.Once);
+  [Fact]
+  public async Task UpdateSubscriptionStatusAsync_WithIncompleteExpired_MapsToCanceled()
+  {
+    // Arrange
+    var userId = 5;
+    var stripeSubscriptionId = "sub_incomplete_expired";
+    var subscription = CreateUserSubscription(userId);
+    subscription.StripeSubscriptionId = stripeSubscriptionId;
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
+        .ReturnsAsync(subscription);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    var result = await _subscriptionService.UpdateSubscriptionStatusAsync(stripeSubscriptionId, "incomplete_expired");
+
+    // Assert - Stripe's incomplete_expired collapses into the local canceled status
+    Assert.Equal(SubscriptionStatus.Canceled, result.Status);
+    Assert.NotNull(result.CanceledAt);
+  }
+
+  [Fact]
+  public async Task UpdateSubscriptionStatusAsync_WithExistingCanceledAt_PreservesOriginalTimestamp()
+  {
+    // Arrange
+    var userId = 6;
+    var stripeSubscriptionId = "sub_already_canceled";
+    var originalCanceledAt = DateTime.UtcNow.AddDays(-3);
+    var subscription = CreateUserSubscription(userId);
+    subscription.StripeSubscriptionId = stripeSubscriptionId;
+    subscription.Status = SubscriptionStatus.PastDue;
+    subscription.CanceledAt = originalCanceledAt;
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
+        .ReturnsAsync(subscription);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+
+    // Act
+    var result = await _subscriptionService.UpdateSubscriptionStatusAsync(stripeSubscriptionId, SubscriptionStatus.Canceled);
+
+    // Assert - CanceledAt is only stamped when null
+    Assert.Equal(SubscriptionStatus.Canceled, result.Status);
+    Assert.Equal(originalCanceledAt, result.CanceledAt);
   }
 
   [Fact]
@@ -501,6 +646,269 @@ public class SubscriptionServiceTests
     // Act + Assert: no exception
     await _subscriptionService.EnforcePlanLimitAsync(userId);
     _mockUnitOfWork.Verify(x => x.SyncConfigs.CountEnabledByUserIdAsync(It.IsAny<int>()), Times.Never);
+  }
+
+  #region SyncFromStripeAsync
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WithExistingLocalRow_UpdatesStatusAndDatesWithoutCreating()
+  {
+    // Arrange
+    var userId = 1;
+    var periodStart = DateTime.UtcNow.AddDays(-1);
+    var periodEnd = DateTime.UtcNow.AddDays(29);
+    var existing = CreateUserSubscription(userId);
+    existing.Status = SubscriptionStatus.Trialing;
+
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_123", "cus_123", SubscriptionStatus.Active, "price_x", periodStart, periodEnd);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_123"))
+        .ReturnsAsync(existing);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert
+    Assert.Equal(SubscriptionStatus.Active, result.Status);
+    Assert.Equal(periodStart, result.CurrentPeriodStart);
+    Assert.Equal(periodEnd, result.CurrentPeriodEnd);
+
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(existing), Times.Once);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WithNoLocalRowAndMetadataUserId_CreatesSubscription()
+  {
+    // Arrange - out-of-order `updated` event arriving before `created` must still create the row
+    var userId = 42;
+    var planId = 7;
+    var periodStart = DateTime.UtcNow;
+    var periodEnd = DateTime.UtcNow.AddDays(30);
+
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_new", "cus_new", SubscriptionStatus.Active, "price_x", periodStart, periodEnd, userId);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_new"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(planId, "Pro"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
+        .ReturnsAsync(false);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => { s.Id = 99; return s; });
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert
+    Assert.Equal(userId, result.UserId);
+    Assert.Equal(planId, result.PlanId);
+    Assert.Equal(SubscriptionStatus.Active, result.Status);
+
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.Is<UserSubscription>(
+        s => s.UserId == userId &&
+             s.PlanId == planId &&
+             s.StripeSubscriptionId == "sub_new" &&
+             s.StripeCustomerId == "cus_new" &&
+             s.Status == SubscriptionStatus.Active &&
+             s.CurrentPeriodStart == periodStart &&
+             s.CurrentPeriodEnd == periodEnd)), Times.Once);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WithNoMetadataUserId_UsesFallbackResolver()
+  {
+    // Arrange
+    var fallbackUserId = 55;
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_fallback", "cus_fallback", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow, DateTime.UtcNow.AddDays(30));
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_fallback"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(fallbackUserId))
+        .ReturnsAsync(false);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(fallbackUserId, AutoDisableReason.SubscriptionInactive))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(
+        stripeSubscription, () => Task.FromResult<int?>(fallbackUserId));
+
+    // Assert
+    Assert.Equal(fallbackUserId, result.UserId);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.Is<UserSubscription>(
+        s => s.UserId == fallbackUserId)), Times.Once);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WithUnresolvableUser_Throws()
+  {
+    // Arrange - no metadata userId and the fallback resolver comes up empty
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_no_user", "cus_no_user", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow, DateTime.UtcNow.AddDays(30));
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_no_user"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _subscriptionService.SyncFromStripeAsync(
+            stripeSubscription, () => Task.FromResult<int?>(null)));
+
+    Assert.Contains("Could not determine user", exception.Message);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_NewSubscriptionWithoutItems_Throws()
+  {
+    // Arrange - no items means no price, so no local plan can be resolved
+    var stripeSubscription = new Stripe.Subscription
+    {
+      Id = "sub_no_items",
+      CustomerId = "cus_no_items",
+      Status = SubscriptionStatus.Active
+    };
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_no_items"))
+        .ReturnsAsync((UserSubscription?)null);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _subscriptionService.SyncFromStripeAsync(stripeSubscription));
+
+    Assert.Contains("no items with a price", exception.Message);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WithUnknownPlanPrice_Throws()
+  {
+    // Arrange
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_unknown_price", "cus_x", SubscriptionStatus.Active, "price_unknown",
+        DateTime.UtcNow, DateTime.UtcNow.AddDays(30), userId: 1);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_unknown_price"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_unknown"))
+        .ReturnsAsync((SubscriptionPlan?)null);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _subscriptionService.SyncFromStripeAsync(stripeSubscription));
+
+    Assert.Contains("No local plan matches Stripe price", exception.Message);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WithIncompleteExpired_StoresCanceled()
+  {
+    // Arrange
+    var userId = 8;
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_expired", "cus_expired", "incomplete_expired", "price_x",
+        DateTime.UtcNow.AddDays(-30), DateTime.UtcNow, userId);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_expired"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
+        .ReturnsAsync(false);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert - incomplete_expired collapses into the local canceled status
+    Assert.Equal(SubscriptionStatus.Canceled, result.Status);
+    Assert.NotNull(result.CanceledAt);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WhenUserAlreadyHasActiveSubscription_StillCreates()
+  {
+    // Arrange - the user paid on Stripe's side; a conflicting local subscription is logged,
+    // not a reason to drop the record
+    var userId = 9;
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_conflict", "cus_conflict", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow, DateTime.UtcNow.AddDays(30), userId);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_conflict"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
+        .ReturnsAsync(true);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert - created despite the conflict, no throw
+    Assert.Equal(userId, result.UserId);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Once);
+  }
+
+  #endregion
+
+  private static Stripe.Subscription CreateStripeSubscription(
+      string subscriptionId,
+      string customerId,
+      string status,
+      string priceId,
+      DateTime periodStart,
+      DateTime periodEnd,
+      int? userId = null)
+  {
+    var subscription = new Stripe.Subscription
+    {
+      Id = subscriptionId,
+      CustomerId = customerId,
+      Status = status,
+      Items = new Stripe.StripeList<Stripe.SubscriptionItem>
+      {
+        Data = new List<Stripe.SubscriptionItem>
+        {
+          new Stripe.SubscriptionItem
+          {
+            Price = new Stripe.Price { Id = priceId },
+            CurrentPeriodStart = periodStart,
+            CurrentPeriodEnd = periodEnd
+          }
+        }
+      }
+    };
+
+    if (userId.HasValue)
+    {
+      subscription.Metadata = new Dictionary<string, string> { { "userId", userId.Value.ToString() } };
+    }
+
+    return subscription;
   }
 
   private static SubscriptionPlan CreateSubscriptionPlanWithLimit(int id, string name, int? maxPlaylists)

--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -677,7 +677,7 @@ public class SubscriptionServiceTests
     Assert.Equal(periodEnd, result.CurrentPeriodEnd);
 
     _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(existing), Times.Once);
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Never);
   }
 
   [Fact]
@@ -698,7 +698,7 @@ public class SubscriptionServiceTests
         .ReturnsAsync(CreateSubscriptionPlan(planId, "Pro"));
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
         .ReturnsAsync(false);
-    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => { s.Id = 99; return s; });
     _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
         .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
@@ -711,7 +711,7 @@ public class SubscriptionServiceTests
     Assert.Equal(planId, result.PlanId);
     Assert.Equal(SubscriptionStatus.Active, result.Status);
 
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.Is<UserSubscription>(
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.Is<UserSubscription>(
         s => s.UserId == userId &&
              s.PlanId == planId &&
              s.StripeSubscriptionId == "sub_new" &&
@@ -719,6 +719,41 @@ public class SubscriptionServiceTests
              s.Status == SubscriptionStatus.Active &&
              s.CurrentPeriodStart == periodStart &&
              s.CurrentPeriodEnd == periodEnd)), Times.Once);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WhenCreateRaceIsLost_FallsBackToUpdatingWinnersRow()
+  {
+    // Arrange - the webhook, checkout/complete, and reconciliation can race to create the
+    // same brand-new subscription. The loser's TryCreateAsync returns null (unique index);
+    // the rerun must find the winner's row and take the update path.
+    var userId = 42;
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_race", "cus_race", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow, DateTime.UtcNow.AddDays(30), userId);
+
+    var winnersRow = CreateUserSubscription(userId);
+    winnersRow.StripeSubscriptionId = "sub_race";
+
+    _mockUnitOfWork.SetupSequence(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_race"))
+        .ReturnsAsync((UserSubscription?)null)
+        .ReturnsAsync(winnersRow);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(7, "Pro"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
+        .ReturnsAsync(false);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert - exactly one create attempt, then the winner's row was updated instead
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Once);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(winnersRow), Times.Once);
+    Assert.Equal(winnersRow.Id, result.Id);
   }
 
   [Fact]
@@ -736,7 +771,7 @@ public class SubscriptionServiceTests
         .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(fallbackUserId))
         .ReturnsAsync(false);
-    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => s);
     _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(fallbackUserId, AutoDisableReason.SubscriptionInactive))
         .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
@@ -747,7 +782,7 @@ public class SubscriptionServiceTests
 
     // Assert
     Assert.Equal(fallbackUserId, result.UserId);
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.Is<UserSubscription>(
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.Is<UserSubscription>(
         s => s.UserId == fallbackUserId)), Times.Once);
   }
 
@@ -770,7 +805,7 @@ public class SubscriptionServiceTests
             stripeSubscription, () => Task.FromResult<int?>(null)));
 
     Assert.Contains("Could not determine user", exception.Message);
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Never);
   }
 
   [Fact]
@@ -792,7 +827,7 @@ public class SubscriptionServiceTests
         () => _subscriptionService.SyncFromStripeAsync(stripeSubscription));
 
     Assert.Contains("no items with a price", exception.Message);
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Never);
   }
 
   [Fact]
@@ -813,7 +848,7 @@ public class SubscriptionServiceTests
         () => _subscriptionService.SyncFromStripeAsync(stripeSubscription));
 
     Assert.Contains("No local plan matches Stripe price", exception.Message);
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Never);
   }
 
   [Fact]
@@ -831,7 +866,7 @@ public class SubscriptionServiceTests
         .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
         .ReturnsAsync(false);
-    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => s);
     _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
         .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
@@ -860,7 +895,7 @@ public class SubscriptionServiceTests
         .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
         .ReturnsAsync(true);
-    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => s);
     _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
         .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
@@ -870,7 +905,7 @@ public class SubscriptionServiceTests
 
     // Assert - created despite the conflict, no throw
     Assert.Equal(userId, result.UserId);
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()), Times.Once);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Once);
   }
 
   #endregion

--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -757,6 +757,36 @@ public class SubscriptionServiceTests
   }
 
   [Fact]
+  public async Task SyncFromStripeAsync_WhenLostRaceButNoWinnerRowExists_ThrowsInsteadOfLooping()
+  {
+    // Arrange - TryCreateAsync reports a unique violation, but no row with this
+    // StripeSubscriptionId can be found. That means the violation came from some other
+    // constraint; retrying the create path would loop forever, so it must throw.
+    var userId = 42;
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_phantom", "cus_phantom", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow, DateTime.UtcNow.AddDays(30), userId);
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_phantom"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(7, "Pro"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
+        .ReturnsAsync(false);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription?)null);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _subscriptionService.SyncFromStripeAsync(stripeSubscription));
+
+    Assert.Contains("different constraint", exception.Message);
+    // Exactly one create attempt — no unbounded re-entry
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Once);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()), Times.Never);
+  }
+
+  [Fact]
   public async Task SyncFromStripeAsync_WithNoMetadataUserId_UsesFallbackResolver()
   {
     // Arrange

--- a/api.Tests/Unit/Services/WebhookRetry/StripeWebhookProcessorTests.cs
+++ b/api.Tests/Unit/Services/WebhookRetry/StripeWebhookProcessorTests.cs
@@ -1,131 +1,139 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
-using RadioWash.Api.Infrastructure.Data;
 using RadioWash.Api.Models.Domain;
 using RadioWash.Api.Services.Implementations;
 using RadioWash.Api.Services.Interfaces;
+using RadioWash.Api.Tests.Unit.Services;
 using Stripe;
 
 namespace RadioWash.Api.Tests.Unit.Services.WebhookRetry;
 
-public class StripeWebhookProcessorTests : IDisposable
+public class StripeWebhookProcessorTests
 {
     private readonly Mock<IConfiguration> _mockConfiguration;
     private readonly Mock<ISubscriptionService> _mockSubscriptionService;
-    private readonly Mock<IEventUtility> _mockEventUtility;
     private readonly Mock<CustomerService> _mockCustomerService;
+    private readonly Mock<Stripe.SubscriptionService> _mockStripeSubscriptionService;
     private readonly Mock<ILogger<StripeWebhookProcessor>> _mockLogger;
-    private readonly RadioWashDbContext _dbContext;
-    private readonly StripeWebhookProcessor _stripeWebhookProcessor;
+    private readonly StripeWebhookProcessor _processor;
 
     public StripeWebhookProcessorTests()
     {
         _mockConfiguration = new Mock<IConfiguration>();
         _mockSubscriptionService = new Mock<ISubscriptionService>();
-        _mockEventUtility = new Mock<IEventUtility>();
         _mockCustomerService = new Mock<CustomerService>();
+        _mockStripeSubscriptionService = new Mock<Stripe.SubscriptionService>();
         _mockLogger = new Mock<ILogger<StripeWebhookProcessor>>();
 
-        // Setup in-memory database
-        var options = new DbContextOptionsBuilder<RadioWashDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-        _dbContext = new RadioWashDbContext(options);
-        _dbContext.Database.EnsureCreated();
-
-        // Setup configuration
         _mockConfiguration.Setup(x => x["Stripe:SecretKey"]).Returns("sk_test_123");
-        _mockConfiguration.Setup(x => x["Stripe:WebhookSecret"]).Returns("whsec_123");
 
-        _stripeWebhookProcessor = new StripeWebhookProcessor(
+        _processor = new StripeWebhookProcessor(
             _mockConfiguration.Object,
             _mockSubscriptionService.Object,
-            _mockEventUtility.Object,
-            _dbContext,
             _mockCustomerService.Object,
+            _mockStripeSubscriptionService.Object,
             _mockLogger.Object);
     }
 
-    #region Configuration Tests
+    /// <summary>
+    /// Deserializes a payload the way the retry pipeline does: no signature involved.
+    /// </summary>
+    private static Event ParseEvent(string payloadJson) =>
+        EventUtility.ParseEvent(payloadJson, throwOnApiVersionMismatch: false);
 
-    [Fact]
-    public async Task ProcessWebhookAsync_WithMissingWebhookSecret_ShouldThrowInvalidOperationException()
+    #region Subscription Created / Updated Tests
+
+    [Theory]
+    [InlineData("created")]
+    [InlineData("updated")]
+    public async Task ProcessEventAsync_WithSubscriptionChangedEvent_ShouldSyncFromStripe(string change)
     {
         // Arrange
-        _mockConfiguration.Setup(x => x["Stripe:WebhookSecret"]).Returns((string?)null);
-        
-        var processor = new StripeWebhookProcessor(
-            _mockConfiguration.Object,
-            _mockSubscriptionService.Object,
-            _mockEventUtility.Object,
-            _dbContext,
-            _mockCustomerService.Object,
-            _mockLogger.Object);
+        var subscriptionId = "sub_123";
+        var payload = change == "created"
+            ? StripeWebhookPayloadBuilder.CreateSubscriptionCreatedWebhook(subscriptionId, "cus_123", "price_123", 17)
+            : StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook(subscriptionId, "active");
+        var stripeEvent = ParseEvent(payload);
+
+        _mockSubscriptionService
+            .Setup(x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()))
+            .ReturnsAsync(CreateUserSubscription());
+
+        // Act
+        await _processor.ProcessEventAsync(stripeEvent);
+
+        // Assert
+        _mockSubscriptionService.Verify(x => x.SyncFromStripeAsync(
+            It.Is<Stripe.Subscription>(s => s.Id == subscriptionId),
+            It.IsAny<Func<Task<int?>>?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessEventAsync_WithSubscriptionUpdatedAndNullDataObject_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var stripeEvent = new Event
+        {
+            Id = "evt_null_object",
+            Type = "customer.subscription.updated",
+            Data = new EventData { Object = null! }
+        };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => processor.ProcessWebhookAsync("payload", "signature"));
-    }
-
-    #endregion
-
-    #region Subscription Updated Tests
-
-    [Fact]
-    public async Task ProcessWebhookAsync_WithSubscriptionUpdated_ShouldUpdateSubscriptionWithDates()
-    {
-        // Arrange
-        var subscriptionId = "sub_123";
-        var eventId = "evt_test_123";
-        var periodStart = DateTime.UtcNow.AddDays(-30);
-        var periodEnd = DateTime.UtcNow.AddDays(30);
-
-        var subscription = CreateMockSubscription(subscriptionId, "active", periodStart, periodEnd);
-        var mockEvent = CreateMockEvent(eventId, "customer.subscription.updated", subscription);
-
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-        _mockSubscriptionService.Setup(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "active"))
-            .ReturnsAsync(CreateMockUserSubscription());
-        _mockSubscriptionService.Setup(x => x.UpdateSubscriptionDatesAsync(subscriptionId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(CreateMockUserSubscription());
-
-        // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
-
-        // Assert
-        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "active"), Times.Once);
-        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionDatesAsync(
-            subscriptionId,
-            It.Is<DateTime>(d => Math.Abs((d - periodStart).TotalSeconds) < 1),
-            It.Is<DateTime>(d => Math.Abs((d - periodEnd).TotalSeconds) < 1)), Times.Once);
+            () => _processor.ProcessEventAsync(stripeEvent));
     }
 
     [Fact]
-    public async Task ProcessWebhookAsync_WithSubscriptionUpdatedNoItems_ShouldOnlyUpdateStatus()
+    public async Task ProcessEventAsync_WithSubscriptionCreated_FallbackShouldResolveUserIdFromCustomerMetadata()
     {
         // Arrange
         var subscriptionId = "sub_123";
-        var eventId = "evt_test_no_items";
+        var customerId = "cus_123";
+        var userId = 17;
+        var payload = StripeWebhookPayloadBuilder.CreateSubscriptionCreatedWebhook(subscriptionId, customerId, "price_123", userId);
+        var stripeEvent = ParseEvent(payload);
 
-        var subscription = new Stripe.Subscription { Id = subscriptionId, Status = "active", Items = null };
-        var mockEvent = CreateMockEvent(eventId, "customer.subscription.updated", subscription);
+        Func<Task<int?>>? capturedFallback = null;
+        _mockSubscriptionService
+            .Setup(x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()))
+            .Callback<Stripe.Subscription, Func<Task<int?>>?>((_, fallback) => capturedFallback = fallback)
+            .ReturnsAsync(CreateUserSubscription());
 
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-        _mockSubscriptionService.Setup(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "active"))
-            .ReturnsAsync(CreateMockUserSubscription());
+        _mockCustomerService
+            .Setup(x => x.GetAsync(customerId, It.IsAny<CustomerGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Customer
+            {
+                Id = customerId,
+                Metadata = new Dictionary<string, string> { { "userId", userId.ToString() } }
+            });
 
         // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
+        await _processor.ProcessEventAsync(stripeEvent);
+        var resolvedUserId = await capturedFallback!.Invoke();
 
         // Assert
-        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "active"), Times.Once);
-        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionDatesAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Never);
+        Assert.Equal(userId, resolvedUserId);
+        _mockCustomerService.Verify(x => x.GetAsync(customerId,
+            It.IsAny<CustomerGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessEventAsync_WhenSyncFromStripeThrows_ShouldPropagate()
+    {
+        // Arrange
+        var payload = StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook("sub_123", "active");
+        var stripeEvent = ParseEvent(payload);
+
+        _mockSubscriptionService
+            .Setup(x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()))
+            .ThrowsAsync(new InvalidOperationException("sync failed"));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _processor.ProcessEventAsync(stripeEvent));
+        Assert.Equal("sync failed", ex.Message);
     }
 
     #endregion
@@ -133,69 +141,38 @@ public class StripeWebhookProcessorTests : IDisposable
     #region Subscription Deleted Tests
 
     [Fact]
-    public async Task ProcessWebhookAsync_WithSubscriptionDeleted_ShouldCancelSubscription()
+    public async Task ProcessEventAsync_WithSubscriptionDeletedAndLocalRecord_ShouldCancelSubscription()
     {
         // Arrange
         var subscriptionId = "sub_123";
-        var eventId = "evt_test_deleted";
+        var payload = StripeWebhookPayloadBuilder.CreateSubscriptionDeletedWebhook(subscriptionId);
+        var stripeEvent = ParseEvent(payload);
 
-        var subscription = new Stripe.Subscription { Id = subscriptionId };
-        var mockEvent = CreateMockEvent(eventId, "customer.subscription.deleted", subscription);
-
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
+        _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync(subscriptionId))
+            .ReturnsAsync(CreateUserSubscription());
         _mockSubscriptionService.Setup(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "canceled"))
-            .ReturnsAsync(CreateMockUserSubscription());
+            .ReturnsAsync(CreateUserSubscription());
 
         // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
+        await _processor.ProcessEventAsync(stripeEvent);
 
         // Assert
         _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "canceled"), Times.Once);
     }
 
-    #endregion
-
-    #region Payment Failed Tests
-
     [Fact]
-    public async Task ProcessWebhookAsync_WithPaymentFailed_ShouldUpdateSubscriptionToPastDue()
+    public async Task ProcessEventAsync_WithSubscriptionDeletedAndNoLocalRecord_ShouldNotUpdateStatus()
     {
         // Arrange
-        var subscriptionId = "sub_123";
-        var invoiceId = "in_123";
-        var eventId = "evt_test_payment_failed";
+        var subscriptionId = "sub_missing";
+        var payload = StripeWebhookPayloadBuilder.CreateSubscriptionDeletedWebhook(subscriptionId);
+        var stripeEvent = ParseEvent(payload);
 
-        var invoice = CreateMockInvoice(invoiceId, subscriptionId);
-        var mockEvent = CreateMockEvent(eventId, "invoice.payment_failed", invoice);
+        _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync(subscriptionId))
+            .ReturnsAsync((UserSubscription?)null);
 
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-        _mockSubscriptionService.Setup(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "past_due"))
-            .ReturnsAsync(CreateMockUserSubscription());
-
-        // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
-
-        // Assert
-        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "past_due"), Times.Once);
-    }
-
-    [Fact]
-    public async Task ProcessWebhookAsync_WithPaymentFailedNoSubscription_ShouldNotUpdateStatus()
-    {
-        // Arrange
-        var invoiceId = "in_123";
-        var eventId = "evt_test_payment_failed_no_sub";
-
-        var invoice = CreateMockInvoice(invoiceId, null);
-        var mockEvent = CreateMockEvent(eventId, "invoice.payment_failed", invoice);
-
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-
-        // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
+        // Act (no throw expected)
+        await _processor.ProcessEventAsync(stripeEvent);
 
         // Assert
         _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -203,89 +180,95 @@ public class StripeWebhookProcessorTests : IDisposable
 
     #endregion
 
-    #region Payment Succeeded Tests
+    #region Invoice Payment Tests
 
-    [Fact]
-    public async Task ProcessWebhookAsync_WithPaymentSucceeded_ShouldUpdateSubscriptionToActive()
+    [Theory]
+    [InlineData("invoice.payment_failed", "past_due")]
+    [InlineData("invoice.payment_succeeded", "active")]
+    public async Task ProcessEventAsync_WithInvoiceEventAndLocalRecord_ShouldUpdateStatus(string eventType, string expectedStatus)
     {
         // Arrange
         var subscriptionId = "sub_123";
-        var invoiceId = "in_123";
-        var eventId = "evt_test_payment_succeeded";
+        var payload = eventType == "invoice.payment_failed"
+            ? StripeWebhookPayloadBuilder.CreateInvoicePaymentFailedWebhook("in_123", subscriptionId)
+            : StripeWebhookPayloadBuilder.CreateInvoicePaymentSucceededWebhook("in_123", subscriptionId);
+        var stripeEvent = ParseEvent(payload);
 
-        var invoice = CreateMockInvoice(invoiceId, subscriptionId);
-        var mockEvent = CreateMockEvent(eventId, "invoice.payment_succeeded", invoice);
-
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-        _mockSubscriptionService.Setup(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "active"))
-            .ReturnsAsync(CreateMockUserSubscription());
+        _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync(subscriptionId))
+            .ReturnsAsync(CreateUserSubscription());
+        _mockSubscriptionService.Setup(x => x.UpdateSubscriptionStatusAsync(subscriptionId, expectedStatus))
+            .ReturnsAsync(CreateUserSubscription());
 
         // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
+        await _processor.ProcessEventAsync(stripeEvent);
 
         // Assert
-        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(subscriptionId, "active"), Times.Once);
+        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(subscriptionId, expectedStatus), Times.Once);
+        _mockSubscriptionService.Verify(x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()), Times.Never);
     }
 
-    #endregion
-
-    #region Subscription Created Tests
-
-    [Fact]
-    public async Task ProcessWebhookAsync_WithSubscriptionCreated_ShouldCreateSubscription()
+    [Theory]
+    [InlineData("invoice.payment_failed")]
+    [InlineData("invoice.payment_succeeded")]
+    public async Task ProcessEventAsync_WithInvoiceEventAndNoSubscriptionReference_ShouldNotTouchSubscriptions(string eventType)
     {
-        // Arrange
-        var subscriptionId = "sub_123";
-        var customerId = "cus_123";
-        var priceId = "price_123";
-        var userId = 17;
-        var planId = 1;
-        var eventId = "evt_test_subscription_created";
+        // Arrange - Invoice with no subscription key at all (not subscription-related).
+        var payload = CreateInvoiceWebhookWithoutSubscriptionKey("in_123", eventType);
+        var stripeEvent = ParseEvent(payload);
 
-        var subscription = CreateMockSubscriptionCreated(subscriptionId, customerId, priceId, userId);
-        var mockEvent = CreateMockEvent(eventId, "customer.subscription.created", subscription);
-        var mockPlan = CreateMockSubscriptionPlan(planId, priceId);
-
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-        _mockSubscriptionService.Setup(x => x.GetPlanByStripePriceIdAsync(priceId))
-            .ReturnsAsync(mockPlan);
-        _mockSubscriptionService.Setup(x => x.CreateSubscriptionAsync(userId, planId, subscriptionId, customerId))
-            .ReturnsAsync(CreateMockUserSubscription());
-
-        // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
+        // Act (no throw expected)
+        await _processor.ProcessEventAsync(stripeEvent);
 
         // Assert
-        _mockSubscriptionService.Verify(x => x.GetPlanByStripePriceIdAsync(priceId), Times.Once);
-        _mockSubscriptionService.Verify(x => x.CreateSubscriptionAsync(userId, planId, subscriptionId, customerId), Times.Once);
+        _mockSubscriptionService.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("invoice.payment_failed")]
+    [InlineData("invoice.payment_succeeded")]
+    public async Task ProcessEventAsync_WithInvoiceEventAndExplicitNullSubscription_ShouldNotTouchSubscriptions(string eventType)
+    {
+        // Arrange - real non-subscription invoices carry an explicit "subscription": null,
+        // which must be treated the same as a missing key.
+        var payload = eventType == "invoice.payment_failed"
+            ? StripeWebhookPayloadBuilder.CreateInvoicePaymentFailedWebhook("in_123", null)
+            : StripeWebhookPayloadBuilder.CreateInvoicePaymentSucceededWebhook("in_123", null);
+        var stripeEvent = ParseEvent(payload);
+
+        // Act (no throw expected)
+        await _processor.ProcessEventAsync(stripeEvent);
+
+        // Assert
+        _mockSubscriptionService.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public async Task ProcessWebhookAsync_WithSubscriptionCreatedNoPlan_ShouldNotCreateSubscription()
+    public async Task ProcessEventAsync_WithInvoiceEventAndNoLocalRecord_ShouldFetchFromStripeAndSync()
     {
         // Arrange
-        var subscriptionId = "sub_123";
-        var customerId = "cus_123";
-        var priceId = "price_unknown";
-        var userId = 17;
-        var eventId = "evt_test_subscription_created_no_plan";
+        var subscriptionId = "sub_not_local";
+        var payload = StripeWebhookPayloadBuilder.CreateInvoicePaymentSucceededWebhook("in_123", subscriptionId);
+        var stripeEvent = ParseEvent(payload);
 
-        var subscription = CreateMockSubscriptionCreated(subscriptionId, customerId, priceId, userId);
-        var mockEvent = CreateMockEvent(eventId, "customer.subscription.created", subscription);
+        var fetchedSubscription = new Stripe.Subscription { Id = subscriptionId, CustomerId = "cus_123" };
 
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-        _mockSubscriptionService.Setup(x => x.GetPlanByStripePriceIdAsync(priceId))
-            .ReturnsAsync((SubscriptionPlan?)null);
+        _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync(subscriptionId))
+            .ReturnsAsync((UserSubscription?)null);
+        _mockStripeSubscriptionService
+            .Setup(x => x.GetAsync(subscriptionId, It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fetchedSubscription);
+        _mockSubscriptionService
+            .Setup(x => x.SyncFromStripeAsync(fetchedSubscription, It.IsAny<Func<Task<int?>>?>()))
+            .ReturnsAsync(CreateUserSubscription());
 
         // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
+        await _processor.ProcessEventAsync(stripeEvent);
 
         // Assert
-        _mockSubscriptionService.Verify(x => x.GetPlanByStripePriceIdAsync(priceId), Times.Once);
-        _mockSubscriptionService.Verify(x => x.CreateSubscriptionAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _mockStripeSubscriptionService.Verify(x => x.GetAsync(subscriptionId,
+            It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockSubscriptionService.Verify(x => x.SyncFromStripeAsync(fetchedSubscription, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     #endregion
@@ -293,28 +276,17 @@ public class StripeWebhookProcessorTests : IDisposable
     #region Checkout Session Completed Tests
 
     [Fact]
-    public async Task ProcessWebhookAsync_WithCheckoutCompleted_ShouldProcessSuccessfully()
+    public async Task ProcessEventAsync_WithCheckoutCompleted_ShouldNotCallSubscriptionService()
     {
         // Arrange
-        var sessionId = "cs_123";
-        var userId = 1;
-        var eventId = "evt_test_checkout_completed";
+        var payload = StripeWebhookPayloadBuilder.CreateCheckoutSessionCompletedWebhook("cs_123", 1);
+        var stripeEvent = ParseEvent(payload);
 
-        var session = new Stripe.Checkout.Session
-        {
-            Id = sessionId,
-            Metadata = new Dictionary<string, string> { { "userId", userId.ToString() } }
-        };
-        var mockEvent = CreateMockEvent(eventId, "checkout.session.completed", session);
+        // Act (no throw expected)
+        await _processor.ProcessEventAsync(stripeEvent);
 
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
-
-        // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
-
-        // Assert - Should complete without error
-        Assert.True(true); // Placeholder assertion - main test is that no exception is thrown
+        // Assert
+        _mockSubscriptionService.VerifyNoOtherCalls();
     }
 
     #endregion
@@ -322,100 +294,58 @@ public class StripeWebhookProcessorTests : IDisposable
     #region Unhandled Event Tests
 
     [Fact]
-    public async Task ProcessWebhookAsync_WithUnhandledEventType_ShouldProcessWithoutError()
+    public async Task ProcessEventAsync_WithUnhandledEventType_ShouldNotThrow()
     {
         // Arrange
-        var eventId = "evt_test_unhandled";
-        var mockEvent = new Event { Id = eventId, Type = "customer.created" };
+        var stripeEvent = new Event { Id = "evt_unhandled", Type = "customer.created" };
 
-        _mockEventUtility.Setup(x => x.ConstructEvent("payload", "signature", "whsec_123"))
-            .Returns(mockEvent);
+        // Act (no throw expected)
+        await _processor.ProcessEventAsync(stripeEvent);
 
-        // Act
-        await _stripeWebhookProcessor.ProcessWebhookAsync("payload", "signature");
-
-        // Assert - Should complete without error
-        Assert.True(true); // Placeholder assertion - main test is that no exception is thrown
+        // Assert
+        _mockSubscriptionService.VerifyNoOtherCalls();
     }
 
     #endregion
 
     #region Helper Methods
 
-    private static Event CreateMockEvent(string eventId, string eventType, object dataObject)
+    /// <summary>
+    /// Builds an invoice event payload whose invoice object omits the "subscription" key
+    /// entirely. StripeWebhookPayloadBuilder's overloads always serialize the key (as JSON
+    /// null when no id is given), and GetSubscriptionIdFromInvoice throws on an explicit
+    /// null token — a known implementation gap.
+    /// </summary>
+    private static string CreateInvoiceWebhookWithoutSubscriptionKey(string invoiceId, string eventType)
     {
-        return new Event
+        var payload = new
         {
-            Id = eventId,
-            Type = eventType,
-            Data = new Stripe.EventData { Object = dataObject as Stripe.IHasObject }
-        };
-    }
-
-    private static Stripe.Subscription CreateMockSubscription(string subscriptionId, string status, DateTime? periodStart = null, DateTime? periodEnd = null)
-    {
-        var subscription = new Stripe.Subscription { Id = subscriptionId, Status = status };
-
-        if (periodStart.HasValue && periodEnd.HasValue)
-        {
-            var subscriptionItem = new SubscriptionItem
+            id = "evt_123",
+            @object = "event",
+            api_version = "2020-08-27",
+            created = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            data = new
             {
-                CurrentPeriodStart = periodStart.Value,
-                CurrentPeriodEnd = periodEnd.Value
-            };
-
-            subscription.Items = new StripeList<SubscriptionItem>
+                @object = new
+                {
+                    id = invoiceId,
+                    @object = "invoice"
+                }
+            },
+            livemode = false,
+            pending_webhooks = 1,
+            request = new
             {
-                Data = new List<SubscriptionItem> { subscriptionItem }
-            };
-        }
-
-        return subscription;
-    }
-
-    private static Invoice CreateMockInvoice(string invoiceId, string? subscriptionId)
-    {
-        var invoice = new Invoice { Id = invoiceId };
-
-        if (!string.IsNullOrEmpty(subscriptionId))
-        {
-            var rawJObject = new Newtonsoft.Json.Linq.JObject
-            {
-                ["subscription"] = subscriptionId
-            };
-
-            var rawJObjectProperty = typeof(StripeEntity).GetProperty("RawJObject",
-                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-            rawJObjectProperty?.SetValue(invoice, rawJObject);
-        }
-
-        return invoice;
-    }
-
-    private static Stripe.Subscription CreateMockSubscriptionCreated(string subscriptionId, string customerId, string priceId, int userId)
-    {
-        var subscription = new Stripe.Subscription
-        {
-            Id = subscriptionId,
-            CustomerId = customerId,
-            Status = "active",
-            Metadata = new Dictionary<string, string> { { "userId", userId.ToString() } }
+                id = "req_123",
+                idempotency_key = (string?)null
+            },
+            type = eventType
         };
 
-        var subscriptionItem = new SubscriptionItem
-        {
-            Price = new Price { Id = priceId }
-        };
-
-        subscription.Items = new StripeList<SubscriptionItem>
-        {
-            Data = new List<SubscriptionItem> { subscriptionItem }
-        };
-
-        return subscription;
+        return System.Text.Json.JsonSerializer.Serialize(payload);
     }
 
-    private static UserSubscription CreateMockUserSubscription()
+    private static UserSubscription CreateUserSubscription()
     {
         return new UserSubscription
         {
@@ -430,25 +360,5 @@ public class StripeWebhookProcessorTests : IDisposable
         };
     }
 
-    private static SubscriptionPlan CreateMockSubscriptionPlan(int planId, string stripePriceId)
-    {
-        return new SubscriptionPlan
-        {
-            Id = planId,
-            Name = "Test Plan",
-            PriceInCents = 500,
-            BillingPeriod = "monthly",
-            StripePriceId = stripePriceId,
-            IsActive = true,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
-        };
-    }
-
     #endregion
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-    }
 }

--- a/api.Tests/Unit/Services/WebhookRetry/StripeWebhookProcessorTests.cs
+++ b/api.Tests/Unit/Services/WebhookRetry/StripeWebhookProcessorTests.cs
@@ -47,26 +47,61 @@ public class StripeWebhookProcessorTests
     [Theory]
     [InlineData("created")]
     [InlineData("updated")]
-    public async Task ProcessEventAsync_WithSubscriptionChangedEvent_ShouldSyncFromStripe(string change)
+    public async Task ProcessEventAsync_WithSubscriptionChangedEvent_ShouldSyncCurrentStateFromStripe(string change)
     {
-        // Arrange
+        // Arrange - the event's embedded subscription is only a pointer; the state written
+        // must come from a fresh Stripe fetch, same as the invoice handlers.
         var subscriptionId = "sub_123";
         var payload = change == "created"
             ? StripeWebhookPayloadBuilder.CreateSubscriptionCreatedWebhook(subscriptionId, "cus_123", "price_123", 17)
             : StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook(subscriptionId, "active");
         var stripeEvent = ParseEvent(payload);
+        var currentStripeState = new Stripe.Subscription { Id = subscriptionId, CustomerId = "cus_123", Status = "active" };
 
+        _mockStripeSubscriptionService
+            .Setup(x => x.GetAsync(subscriptionId, It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currentStripeState);
         _mockSubscriptionService
-            .Setup(x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()))
+            .Setup(x => x.SyncFromStripeAsync(currentStripeState, It.IsAny<Func<Task<int?>>?>()))
             .ReturnsAsync(CreateUserSubscription());
 
         // Act
         await _processor.ProcessEventAsync(stripeEvent);
 
-        // Assert
+        // Assert - synced from the fetched state, not the event snapshot
+        _mockStripeSubscriptionService.Verify(x => x.GetAsync(subscriptionId,
+            It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockSubscriptionService.Verify(x => x.SyncFromStripeAsync(
-            It.Is<Stripe.Subscription>(s => s.Id == subscriptionId),
-            It.IsAny<Func<Task<int?>>?>()), Times.Once);
+            currentStripeState, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessEventAsync_WithStaleActiveSnapshot_ShouldNotResurrectCanceledSubscription()
+    {
+        // Arrange - Stripe can redeliver a failed `updated` event for up to 3 days. Its
+        // embedded snapshot says "active", but the subscription has since been canceled;
+        // applying the snapshot would re-entitle a canceled user for free. The current
+        // (canceled) Stripe state must be what gets synced.
+        var subscriptionId = "sub_since_canceled";
+        var payload = StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook(subscriptionId, "active");
+        var stripeEvent = ParseEvent(payload);
+        var currentStripeState = new Stripe.Subscription { Id = subscriptionId, Status = "canceled" };
+
+        _mockStripeSubscriptionService
+            .Setup(x => x.GetAsync(subscriptionId, It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currentStripeState);
+        _mockSubscriptionService
+            .Setup(x => x.SyncFromStripeAsync(currentStripeState, It.IsAny<Func<Task<int?>>?>()))
+            .ReturnsAsync(CreateUserSubscription());
+
+        // Act
+        await _processor.ProcessEventAsync(stripeEvent);
+
+        // Assert - only the fetched canceled state is synced; the stale active snapshot never is
+        _mockSubscriptionService.Verify(x => x.SyncFromStripeAsync(
+            It.Is<Stripe.Subscription>(s => s.Status == "canceled"), It.IsAny<Func<Task<int?>>?>()), Times.Once);
+        _mockSubscriptionService.Verify(x => x.SyncFromStripeAsync(
+            It.Is<Stripe.Subscription>(s => s.Status == "active"), It.IsAny<Func<Task<int?>>?>()), Times.Never);
     }
 
     [Fact]
@@ -94,6 +129,10 @@ public class StripeWebhookProcessorTests
         var userId = 17;
         var payload = StripeWebhookPayloadBuilder.CreateSubscriptionCreatedWebhook(subscriptionId, customerId, "price_123", userId);
         var stripeEvent = ParseEvent(payload);
+
+        _mockStripeSubscriptionService
+            .Setup(x => x.GetAsync(subscriptionId, It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Stripe.Subscription { Id = subscriptionId, CustomerId = customerId, Status = "active" });
 
         Func<Task<int?>>? capturedFallback = null;
         _mockSubscriptionService
@@ -126,6 +165,9 @@ public class StripeWebhookProcessorTests
         var payload = StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook("sub_123", "active");
         var stripeEvent = ParseEvent(payload);
 
+        _mockStripeSubscriptionService
+            .Setup(x => x.GetAsync("sub_123", It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Stripe.Subscription { Id = "sub_123", Status = "active" });
         _mockSubscriptionService
             .Setup(x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()))
             .ThrowsAsync(new InvalidOperationException("sync failed"));

--- a/api.Tests/Unit/Services/WebhookRetry/StripeWebhookProcessorTests.cs
+++ b/api.Tests/Unit/Services/WebhookRetry/StripeWebhookProcessorTests.cs
@@ -183,28 +183,33 @@ public class StripeWebhookProcessorTests
     #region Invoice Payment Tests
 
     [Theory]
-    [InlineData("invoice.payment_failed", "past_due")]
-    [InlineData("invoice.payment_succeeded", "active")]
-    public async Task ProcessEventAsync_WithInvoiceEventAndLocalRecord_ShouldUpdateStatus(string eventType, string expectedStatus)
+    [InlineData("invoice.payment_failed")]
+    [InlineData("invoice.payment_succeeded")]
+    public async Task ProcessEventAsync_WithInvoiceEvent_ShouldSyncCurrentStateFromStripe(string eventType)
     {
-        // Arrange
+        // Arrange - invoice events only carry a subscription pointer; the processor must
+        // fetch the subscription's CURRENT state from Stripe rather than deriving a status
+        // from the event type (a delayed redelivery of payment_succeeded must not resurrect
+        // a since-canceled subscription).
         var subscriptionId = "sub_123";
         var payload = eventType == "invoice.payment_failed"
             ? StripeWebhookPayloadBuilder.CreateInvoicePaymentFailedWebhook("in_123", subscriptionId)
             : StripeWebhookPayloadBuilder.CreateInvoicePaymentSucceededWebhook("in_123", subscriptionId);
         var stripeEvent = ParseEvent(payload);
+        var currentStripeState = new Stripe.Subscription { Id = subscriptionId, Status = "past_due" };
 
-        _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync(subscriptionId))
-            .ReturnsAsync(CreateUserSubscription());
-        _mockSubscriptionService.Setup(x => x.UpdateSubscriptionStatusAsync(subscriptionId, expectedStatus))
-            .ReturnsAsync(CreateUserSubscription());
+        _mockStripeSubscriptionService
+            .Setup(x => x.GetAsync(subscriptionId, It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currentStripeState);
 
         // Act
         await _processor.ProcessEventAsync(stripeEvent);
 
         // Assert
-        _mockSubscriptionService.Verify(x => x.UpdateSubscriptionStatusAsync(subscriptionId, expectedStatus), Times.Once);
-        _mockSubscriptionService.Verify(x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()), Times.Never);
+        _mockSubscriptionService.Verify(
+            x => x.SyncFromStripeAsync(currentStripeState, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+        _mockSubscriptionService.Verify(
+            x => x.UpdateSubscriptionStatusAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [Theory]

--- a/api.Tests/Unit/Services/WebhookRetry/WebhookRetryServiceTests.cs
+++ b/api.Tests/Unit/Services/WebhookRetry/WebhookRetryServiceTests.cs
@@ -399,7 +399,7 @@ public class WebhookRetryServiceTests : IDisposable
     #region ProcessRetryAsync Tests
 
     [Fact]
-    public async Task ProcessRetryAsync_WhenEventAlreadyClaimed_ShouldMarkSucceededWithoutProcessing()
+    public async Task ProcessRetryAsync_WhenEventAlreadyClaimed_ShouldMarkSupersededWithoutProcessing()
     {
         // Arrange
         var retry = await AddRetryAsync("evt_superseded");
@@ -409,9 +409,10 @@ public class WebhookRetryServiceTests : IDisposable
         // Act
         await _webhookRetryService.ProcessRetryAsync(retry);
 
-        // Assert - Superseded retries close out as Succeeded without touching the processor
+        // Assert - closed out as Superseded (not Succeeded: this retry did no work) without
+        // touching the processor
         var stored = await _dbContext.WebhookRetries.FindAsync(retry.Id);
-        Assert.Equal(WebhookRetryStatus.Succeeded, stored!.Status);
+        Assert.Equal(WebhookRetryStatus.Superseded, stored!.Status);
         _mockEventUtility.Verify(x => x.ParseEvent(It.IsAny<string>()), Times.Never);
         _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(It.IsAny<Event>()), Times.Never);
         _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(It.IsAny<string>()), Times.Never);

--- a/api.Tests/Unit/Services/WebhookRetry/WebhookRetryServiceTests.cs
+++ b/api.Tests/Unit/Services/WebhookRetry/WebhookRetryServiceTests.cs
@@ -233,6 +233,82 @@ public class WebhookRetryServiceTests : IDisposable
         Assert.Equal(baseTime.AddMinutes(2), retry.UpdatedAt);
     }
 
+    [Fact]
+    public async Task ScheduleRetryAsync_WithLowerAttemptNumber_ShouldNotResetEscalation()
+    {
+        // Arrange - the internal loop has already escalated this event to attempt 4; a
+        // failing Stripe redelivery then calls ScheduleRetryAsync with the default attempt
+        // number (1). The escalation and backoff progress must not be reset, otherwise the
+        // MaxRetries bound never terminates while Stripe keeps redelivering.
+        var eventId = "evt_no_reset";
+        var baseTime = new DateTime(2024, 10, 25, 12, 0, 0, DateTimeKind.Utc);
+        _testDateTimeProvider.SetUtcNow(baseTime);
+        _testRandomProvider.SetFixedValue(0.5);
+
+        _dbContext.WebhookRetries.Add(new RadioWash.Api.Models.Domain.WebhookRetry
+        {
+            EventId = eventId,
+            EventType = "customer.subscription.updated",
+            Payload = "test_payload",
+            Signature = "test_signature",
+            AttemptNumber = 4,
+            MaxRetries = 5,
+            Status = WebhookRetryStatus.Failed,
+            NextRetryAt = baseTime,
+            LastErrorMessage = "attempt 4 failed",
+            CreatedAt = baseTime.AddHours(-1),
+            UpdatedAt = baseTime
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Act - live redelivery failure re-arms with the default attemptNumber of 1
+        await _webhookRetryService.ScheduleRetryAsync(
+            eventId, "customer.subscription.updated", "test_payload", "test_signature", "redelivery failed");
+
+        // Assert - counter kept at 4, backoff calculated from attempt 4 (8 minutes), re-armed
+        var retry = await _dbContext.WebhookRetries.FirstAsync(wr => wr.EventId == eventId);
+        Assert.Equal(4, retry.AttemptNumber);
+        Assert.Equal(WebhookRetryStatus.Pending, retry.Status);
+        Assert.Equal(baseTime.AddMinutes(8), retry.NextRetryAt); // 1 * 2^(4-1) = 8 minutes
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_WhenMaxRetriesExceeded_ShouldNotReArm()
+    {
+        // Arrange - the internal loop already gave up; Stripe's own redelivery is the
+        // remaining recovery path. Re-arming would bypass the MaxRetries bound on every
+        // failing redelivery.
+        var eventId = "evt_exhausted";
+        var baseTime = new DateTime(2024, 10, 25, 12, 0, 0, DateTimeKind.Utc);
+        _testDateTimeProvider.SetUtcNow(baseTime);
+
+        _dbContext.WebhookRetries.Add(new RadioWash.Api.Models.Domain.WebhookRetry
+        {
+            EventId = eventId,
+            EventType = "customer.subscription.updated",
+            Payload = "test_payload",
+            Signature = "test_signature",
+            AttemptNumber = 5,
+            MaxRetries = 5,
+            Status = WebhookRetryStatus.MaxRetriesExceeded,
+            NextRetryAt = baseTime.AddHours(-1),
+            LastErrorMessage = "gave up",
+            CreatedAt = baseTime.AddHours(-2),
+            UpdatedAt = baseTime.AddHours(-1)
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await _webhookRetryService.ScheduleRetryAsync(
+            eventId, "customer.subscription.updated", "test_payload", "test_signature", "redelivery failed");
+
+        // Assert - untouched
+        var retry = await _dbContext.WebhookRetries.FirstAsync(wr => wr.EventId == eventId);
+        Assert.Equal(WebhookRetryStatus.MaxRetriesExceeded, retry.Status);
+        Assert.Equal(5, retry.AttemptNumber);
+        Assert.Equal("gave up", retry.LastErrorMessage);
+    }
+
     #endregion
 
     #region GetPendingRetriesAsync Tests

--- a/api.Tests/Unit/Services/WebhookRetry/WebhookRetryServiceTests.cs
+++ b/api.Tests/Unit/Services/WebhookRetry/WebhookRetryServiceTests.cs
@@ -7,6 +7,7 @@ using RadioWash.Api.Models.Domain;
 using RadioWash.Api.Services.Implementations;
 using RadioWash.Api.Services.Interfaces;
 using RadioWash.Api.Tests.Unit.TestHelpers;
+using Stripe;
 
 namespace RadioWash.Api.Tests.Unit.Services.WebhookRetry;
 
@@ -14,6 +15,8 @@ public class WebhookRetryServiceTests : IDisposable
 {
     private readonly Mock<ILogger<WebhookRetryService>> _mockLogger;
     private readonly Mock<IWebhookProcessor> _mockWebhookProcessor;
+    private readonly Mock<IEventUtility> _mockEventUtility;
+    private readonly Mock<IIdempotencyService> _mockIdempotencyService;
     private readonly Mock<IErrorClassifier> _mockErrorClassifier;
     private readonly TestDateTimeProvider _testDateTimeProvider;
     private readonly TestRandomProvider _testRandomProvider;
@@ -24,6 +27,8 @@ public class WebhookRetryServiceTests : IDisposable
     {
         _mockLogger = new Mock<ILogger<WebhookRetryService>>();
         _mockWebhookProcessor = new Mock<IWebhookProcessor>();
+        _mockEventUtility = new Mock<IEventUtility>();
+        _mockIdempotencyService = new Mock<IIdempotencyService>();
         _mockErrorClassifier = new Mock<IErrorClassifier>();
         _testDateTimeProvider = new TestDateTimeProvider();
         _testRandomProvider = new TestRandomProvider();
@@ -40,6 +45,8 @@ public class WebhookRetryServiceTests : IDisposable
             _dbContext,
             _mockLogger.Object,
             _mockWebhookProcessor.Object,
+            _mockEventUtility.Object,
+            _mockIdempotencyService.Object,
             _testDateTimeProvider,
             _testRandomProvider,
             _mockErrorClassifier.Object);
@@ -385,6 +392,165 @@ public class WebhookRetryServiceTests : IDisposable
 
         // Assert
         Assert.Equal(50, result.Count()); // Should be limited to batch size
+    }
+
+    #endregion
+
+    #region ProcessRetryAsync Tests
+
+    [Fact]
+    public async Task ProcessRetryAsync_WhenEventAlreadyClaimed_ShouldMarkSucceededWithoutProcessing()
+    {
+        // Arrange
+        var retry = await AddRetryAsync("evt_superseded");
+        _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(retry.EventId, retry.EventType))
+            .ReturnsAsync(false);
+
+        // Act
+        await _webhookRetryService.ProcessRetryAsync(retry);
+
+        // Assert - Superseded retries close out as Succeeded without touching the processor
+        var stored = await _dbContext.WebhookRetries.FindAsync(retry.Id);
+        Assert.Equal(WebhookRetryStatus.Succeeded, stored!.Status);
+        _mockEventUtility.Verify(x => x.ParseEvent(It.IsAny<string>()), Times.Never);
+        _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(It.IsAny<Event>()), Times.Never);
+        _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessRetryAsync_WhenClaimed_ShouldParseWithoutSignatureAndProcess()
+    {
+        // Arrange
+        var retry = await AddRetryAsync("evt_claimed");
+        var parsedEvent = new Event { Id = retry.EventId, Type = retry.EventType };
+
+        _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(retry.EventId, retry.EventType))
+            .ReturnsAsync(true);
+        _mockEventUtility.Setup(x => x.ParseEvent(retry.Payload)).Returns(parsedEvent);
+
+        // Act
+        await _webhookRetryService.ProcessRetryAsync(retry);
+
+        // Assert
+        _mockEventUtility.Verify(x => x.ParseEvent(retry.Payload), Times.Once);
+        _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(parsedEvent), Times.Once);
+        _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(retry.EventId), Times.Once);
+
+        var stored = await _dbContext.WebhookRetries.FindAsync(retry.Id);
+        Assert.Equal(WebhookRetryStatus.Succeeded, stored!.Status);
+
+        // The stored payload was verified on first receipt; the retry path must never
+        // attempt signature re-verification.
+        _mockEventUtility.Verify(x => x.ConstructEvent(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessRetryAsync_WithStaleSignatureTimestamp_ShouldStillProcess()
+    {
+        // Arrange - A stored payload whose Stripe-Signature timestamp is far outside the
+        // 5-minute tolerance. Re-verification would be impossible; only parsing is used.
+        var payload = StripeWebhookPayloadBuilder.CreateSubscriptionUpdatedWebhook("sub_123", "active");
+        var staleTimestamp = DateTimeOffset.UtcNow.AddSeconds(-600).ToUnixTimeSeconds();
+        var staleSignature = $"t={staleTimestamp},v1=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+        var retry = await AddRetryAsync("evt_123", payload, staleSignature);
+        var parsedEvent = EventUtility.ParseEvent(payload, throwOnApiVersionMismatch: false);
+
+        _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(retry.EventId, retry.EventType))
+            .ReturnsAsync(true);
+        _mockEventUtility.Setup(x => x.ParseEvent(payload)).Returns(parsedEvent);
+
+        // Act
+        await _webhookRetryService.ProcessRetryAsync(retry);
+
+        // Assert - Processed despite the >300-second-old signature timestamp
+        _mockWebhookProcessor.Verify(x => x.ProcessEventAsync(parsedEvent), Times.Once);
+        _mockEventUtility.Verify(x => x.ConstructEvent(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+        var stored = await _dbContext.WebhookRetries.FindAsync(retry.Id);
+        Assert.Equal(WebhookRetryStatus.Succeeded, stored!.Status);
+    }
+
+    [Fact]
+    public async Task ProcessRetryAsync_WhenProcessorThrows_ShouldMarkEventFailedAndScheduleNextRetry()
+    {
+        // Arrange
+        var baseTime = new DateTime(2024, 10, 25, 12, 0, 0, DateTimeKind.Utc);
+        _testDateTimeProvider.SetUtcNow(baseTime);
+        _testRandomProvider.SetFixedValue(0.5); // No jitter
+
+        var retry = await AddRetryAsync("evt_failing");
+        var parsedEvent = new Event { Id = retry.EventId, Type = retry.EventType };
+
+        _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(retry.EventId, retry.EventType))
+            .ReturnsAsync(true);
+        _mockEventUtility.Setup(x => x.ParseEvent(retry.Payload)).Returns(parsedEvent);
+        _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(parsedEvent))
+            .ThrowsAsync(new InvalidOperationException("Processing failed"));
+
+        // Act
+        await _webhookRetryService.ProcessRetryAsync(retry);
+
+        // Assert
+        _mockIdempotencyService.Verify(x => x.MarkEventFailedAsync(retry.EventId, "Processing failed"), Times.Once);
+        _mockIdempotencyService.Verify(x => x.MarkEventSuccessfulAsync(It.IsAny<string>()), Times.Never);
+
+        var stored = await _dbContext.WebhookRetries.FindAsync(retry.Id);
+        Assert.Equal(WebhookRetryStatus.Pending, stored!.Status);
+        Assert.Equal(2, stored.AttemptNumber);
+        Assert.Equal("Processing failed", stored.LastErrorMessage);
+        Assert.Equal(baseTime.AddMinutes(2), stored.NextRetryAt); // Second attempt = 2 minutes
+    }
+
+    [Fact]
+    public async Task ProcessRetryAsync_WhenProcessorThrowsAtMaxRetries_ShouldMarkMaxRetriesExceeded()
+    {
+        // Arrange
+        var retry = await AddRetryAsync("evt_maxed_out", attemptNumber: 5);
+        var parsedEvent = new Event { Id = retry.EventId, Type = retry.EventType };
+
+        _mockIdempotencyService.Setup(x => x.TryProcessEventAsync(retry.EventId, retry.EventType))
+            .ReturnsAsync(true);
+        _mockEventUtility.Setup(x => x.ParseEvent(retry.Payload)).Returns(parsedEvent);
+        _mockWebhookProcessor.Setup(x => x.ProcessEventAsync(parsedEvent))
+            .ThrowsAsync(new InvalidOperationException("Still failing"));
+
+        // Act
+        await _webhookRetryService.ProcessRetryAsync(retry);
+
+        // Assert
+        _mockIdempotencyService.Verify(x => x.MarkEventFailedAsync(retry.EventId, "Still failing"), Times.Once);
+
+        var stored = await _dbContext.WebhookRetries.FindAsync(retry.Id);
+        Assert.Equal(WebhookRetryStatus.MaxRetriesExceeded, stored!.Status);
+        Assert.Equal(5, stored.AttemptNumber);
+    }
+
+    private async Task<RadioWash.Api.Models.Domain.WebhookRetry> AddRetryAsync(
+        string eventId,
+        string payload = "test_payload",
+        string signature = "test_signature",
+        int attemptNumber = 1)
+    {
+        var now = _testDateTimeProvider.UtcNow;
+        var retry = new RadioWash.Api.Models.Domain.WebhookRetry
+        {
+            EventId = eventId,
+            EventType = "customer.subscription.updated",
+            Payload = payload,
+            Signature = signature,
+            AttemptNumber = attemptNumber,
+            MaxRetries = 5,
+            Status = WebhookRetryStatus.Pending,
+            NextRetryAt = now.AddMinutes(-1),
+            LastErrorMessage = "Initial error",
+            CreatedAt = now.AddMinutes(-10),
+            UpdatedAt = now.AddMinutes(-10)
+        };
+
+        _dbContext.WebhookRetries.Add(retry);
+        await _dbContext.SaveChangesAsync();
+        return retry;
     }
 
     #endregion

--- a/api/Controllers/SubscriptionController.cs
+++ b/api/Controllers/SubscriptionController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using RadioWash.Api.Infrastructure.Data;
 using RadioWash.Api.Models.DTO;
+using RadioWash.Api.Services.Exceptions;
 using RadioWash.Api.Services.Interfaces;
 using System.Text.Json;
 
@@ -148,23 +149,32 @@ public class SubscriptionController : AuthenticatedControllerBase
   [AllowAnonymous]
   public async Task<ActionResult> HandleStripeWebhook()
   {
+    var json = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+    var signature = Request.Headers["Stripe-Signature"].FirstOrDefault();
+
+    if (string.IsNullOrEmpty(signature))
+    {
+      return BadRequest("Missing Stripe signature");
+    }
+
     try
     {
-      var json = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
-      var signature = Request.Headers["Stripe-Signature"].FirstOrDefault();
-
-      if (string.IsNullOrEmpty(signature))
-      {
-        return BadRequest("Missing Stripe signature");
-      }
-
       await _paymentService.HandleWebhookAsync(json, signature);
       return Ok();
     }
+    catch (WebhookSignatureVerificationException ex)
+    {
+      // 400 tells Stripe the delivery is permanently rejected — reserved for payloads
+      // that fail authentication.
+      _logger.LogWarning(ex, "Rejected Stripe webhook with invalid signature");
+      return BadRequest("Invalid Stripe signature");
+    }
     catch (Exception ex)
     {
+      // 500 makes Stripe redeliver with backoff for up to 3 days; combined with the
+      // released idempotency claim, transient failures self-heal.
       _logger.LogError(ex, "Error processing Stripe webhook");
-      return BadRequest("Webhook processing failed");
+      return StatusCode(StatusCodes.Status500InternalServerError, "Webhook processing failed");
     }
   }
 

--- a/api/Infrastructure/Data/DbUpdateExceptionExtensions.cs
+++ b/api/Infrastructure/Data/DbUpdateExceptionExtensions.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace RadioWash.Api.Infrastructure.Data;
+
+public static class DbUpdateExceptionExtensions
+{
+  /// <summary>
+  /// True when the failed save was rejected by a unique constraint — the signal callers use
+  /// to treat an insert as "lost a benign race" rather than a real error. A PostgresException
+  /// is classified by SqlState alone (23505) and never falls through to message matching, so
+  /// other Postgres failures whose text happens to mention "unique" are not swallowed.
+  /// </summary>
+  public static bool IsUniqueConstraintViolation(this DbUpdateException ex)
+  {
+    if (ex.InnerException is Npgsql.PostgresException pgEx)
+    {
+      return pgEx.SqlState == "23505";
+    }
+
+    // Fallback for the EF InMemory provider used in unit tests, which surfaces unique
+    // index violations as a plain exception message.
+    return ex.InnerException?.Message?.Contains("unique", StringComparison.OrdinalIgnoreCase) == true
+        || ex.Message.Contains("same key", StringComparison.OrdinalIgnoreCase);
+  }
+}

--- a/api/Infrastructure/Data/RadioWashDbContext.cs
+++ b/api/Infrastructure/Data/RadioWashDbContext.cs
@@ -159,6 +159,12 @@ public class RadioWashDbContext : DbContext, IDataProtectionKeyContext
     modelBuilder.Entity<ProcessedWebhookEvent>()
         .HasIndex(pwe => pwe.ProcessedAt);
 
+    // Status doubles as the claim state: takeover of a Failed/stale-Processing row is a
+    // compare-and-swap on this column, so concurrent claimants can't both win.
+    modelBuilder.Entity<ProcessedWebhookEvent>()
+        .Property(pwe => pwe.Status)
+        .IsConcurrencyToken();
+
     // Webhook Retry configuration
     modelBuilder.Entity<WebhookRetry>()
         .HasIndex(wr => wr.EventId);

--- a/api/Infrastructure/Data/RadioWashDbContext.cs
+++ b/api/Infrastructure/Data/RadioWashDbContext.cs
@@ -159,10 +159,16 @@ public class RadioWashDbContext : DbContext, IDataProtectionKeyContext
     modelBuilder.Entity<ProcessedWebhookEvent>()
         .HasIndex(pwe => pwe.ProcessedAt);
 
-    // Status doubles as the claim state: takeover of a Failed/stale-Processing row is a
-    // compare-and-swap on this column, so concurrent claimants can't both win.
+    // Status + LastAttemptAt together form the claim state for compare-and-swap takeovers.
+    // Status alone is NOT enough: a stale-Processing takeover writes Processing -> Processing
+    // (value unchanged), so only LastAttemptAt — which changes on every claim — makes that
+    // CAS real. With both as concurrency tokens, concurrent claimants can't all win.
     modelBuilder.Entity<ProcessedWebhookEvent>()
         .Property(pwe => pwe.Status)
+        .IsConcurrencyToken();
+
+    modelBuilder.Entity<ProcessedWebhookEvent>()
+        .Property(pwe => pwe.LastAttemptAt)
         .IsConcurrencyToken();
 
     // Webhook Retry configuration

--- a/api/Infrastructure/Repositories/IUserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/IUserSubscriptionRepository.cs
@@ -15,6 +15,10 @@ public interface IUserSubscriptionRepository
   Task<IEnumerable<UserSubscription>> GetExpiringSubscriptionsWithDetailsAsync(DateTime before);
   Task<IEnumerable<UserSubscription>> GetExpiredActiveSubscriptionsAsync(DateTime cutoff);
   Task<UserSubscription> CreateAsync(UserSubscription subscription);
+  // Returns null when a concurrent writer already created a row for the same
+  // StripeSubscriptionId (unique filtered index); the failed insert is detached so the
+  // context remains usable for a follow-up read/update.
+  Task<UserSubscription?> TryCreateAsync(UserSubscription subscription);
   Task<UserSubscription> UpdateAsync(UserSubscription subscription);
   Task<bool> HasActiveSubscriptionAsync(int userId);
   Task SaveChangesAsync();

--- a/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
@@ -111,6 +111,30 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
     return subscription;
   }
 
+  public async Task<UserSubscription?> TryCreateAsync(UserSubscription subscription)
+  {
+    _dbContext.UserSubscriptions.Add(subscription);
+    try
+    {
+      await _dbContext.SaveChangesAsync();
+      return subscription;
+    }
+    catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+    {
+      _dbContext.Entry(subscription).State = EntityState.Detached;
+      return null;
+    }
+  }
+
+  private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+  {
+    // Postgres reports unique violations via SqlState 23505; the message checks cover the
+    // EF InMemory provider used in unit tests.
+    return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505"
+        || ex.InnerException?.Message?.Contains("unique", StringComparison.OrdinalIgnoreCase) == true
+        || ex.Message.Contains("same key", StringComparison.OrdinalIgnoreCase);
+  }
+
   public async Task<UserSubscription> UpdateAsync(UserSubscription subscription)
   {
     subscription.UpdatedAt = DateTime.UtcNow;

--- a/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
@@ -119,20 +119,11 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
       await _dbContext.SaveChangesAsync();
       return subscription;
     }
-    catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+    catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
     {
       _dbContext.Entry(subscription).State = EntityState.Detached;
       return null;
     }
-  }
-
-  private static bool IsUniqueConstraintViolation(DbUpdateException ex)
-  {
-    // Postgres reports unique violations via SqlState 23505; the message checks cover the
-    // EF InMemory provider used in unit tests.
-    return ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505"
-        || ex.InnerException?.Message?.Contains("unique", StringComparison.OrdinalIgnoreCase) == true
-        || ex.Message.Contains("same key", StringComparison.OrdinalIgnoreCase);
   }
 
   public async Task<UserSubscription> UpdateAsync(UserSubscription subscription)

--- a/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
@@ -55,7 +55,7 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
   {
     return await _dbContext.UserSubscriptions
         .AsNoTracking()
-        .Where(us => us.Status == SubscriptionStatus.Active)
+        .Where(us => us.Status == SubscriptionStatus.Active || us.Status == SubscriptionStatus.Trialing)
         .ToListAsync();
   }
 
@@ -64,7 +64,7 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
     return await _dbContext.UserSubscriptions
         .Include(us => us.User)
         .Include(us => us.Plan)
-        .Where(us => us.Status == SubscriptionStatus.Active)
+        .Where(us => us.Status == SubscriptionStatus.Active || us.Status == SubscriptionStatus.Trialing)
         .ToListAsync();
   }
 
@@ -95,8 +95,10 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
   // skipped because they represent an incomplete state Stripe hasn't finalized.
   public async Task<IEnumerable<UserSubscription>> GetExpiredActiveSubscriptionsAsync(DateTime cutoff)
   {
+    // Trialing counts as entitled, so a stale trial whose renewal webhooks were lost must
+    // expire here just like a stale active subscription.
     return await _dbContext.UserSubscriptions
-        .Where(us => us.Status == SubscriptionStatus.Active &&
+        .Where(us => (us.Status == SubscriptionStatus.Active || us.Status == SubscriptionStatus.Trialing) &&
                     us.CurrentPeriodEnd.HasValue &&
                     us.CurrentPeriodEnd.Value < cutoff)
         .ToListAsync();
@@ -119,9 +121,10 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
 
   public async Task<bool> HasActiveSubscriptionAsync(int userId)
   {
+    // Trialing subscriptions are entitled to paid features, same as active ones.
     return await _dbContext.UserSubscriptions
         .AnyAsync(us => us.UserId == userId &&
-                       us.Status == SubscriptionStatus.Active &&
+                       (us.Status == SubscriptionStatus.Active || us.Status == SubscriptionStatus.Trialing) &&
                        (us.CurrentPeriodEnd == null || us.CurrentPeriodEnd > DateTime.UtcNow));
   }
 

--- a/api/Migrations/20260804122803_RestructureProcessedWebhookEventClaims.Designer.cs
+++ b/api/Migrations/20260804122803_RestructureProcessedWebhookEventClaims.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RadioWash.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using RadioWash.Api.Infrastructure.Data;
 namespace RadioWash.Api.Migrations
 {
     [DbContext(typeof(RadioWashDbContext))]
-    partial class RadioWashDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804122803_RestructureProcessedWebhookEventClaims")]
+    partial class RestructureProcessedWebhookEventClaims
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20260804122803_RestructureProcessedWebhookEventClaims.cs
+++ b/api/Migrations/20260804122803_RestructureProcessedWebhookEventClaims.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RadioWash.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestructureProcessedWebhookEventClaims : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AttemptCount",
+                table: "ProcessedWebhookEvents",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastAttemptAt",
+                table: "ProcessedWebhookEvents",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "ProcessedWebhookEvents",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            // Backfill claim state from the old boolean: true -> Succeeded (1), false ->
+            // Failed (2). No row can legitimately be mid-Processing during a deploy, and
+            // Failed keeps previously-failed events re-claimable by design.
+            migrationBuilder.Sql(
+                """
+                UPDATE "ProcessedWebhookEvents"
+                SET "Status" = CASE WHEN "IsSuccessful" THEN 1 ELSE 2 END,
+                    "LastAttemptAt" = "ProcessedAt";
+                """);
+
+            migrationBuilder.DropColumn(
+                name: "IsSuccessful",
+                table: "ProcessedWebhookEvents");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSuccessful",
+                table: "ProcessedWebhookEvents",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "ProcessedWebhookEvents"
+                SET "IsSuccessful" = ("Status" = 1);
+                """);
+
+            migrationBuilder.DropColumn(
+                name: "AttemptCount",
+                table: "ProcessedWebhookEvents");
+
+            migrationBuilder.DropColumn(
+                name: "LastAttemptAt",
+                table: "ProcessedWebhookEvents");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "ProcessedWebhookEvents");
+        }
+    }
+}

--- a/api/Migrations/20260804130406_RestructureProcessedWebhookEventClaims.Designer.cs
+++ b/api/Migrations/20260804130406_RestructureProcessedWebhookEventClaims.Designer.cs
@@ -12,7 +12,7 @@ using RadioWash.Api.Infrastructure.Data;
 namespace RadioWash.Api.Migrations
 {
     [DbContext(typeof(RadioWashDbContext))]
-    [Migration("20260804122803_RestructureProcessedWebhookEventClaims")]
+    [Migration("20260804130406_RestructureProcessedWebhookEventClaims")]
     partial class RestructureProcessedWebhookEventClaims
     {
         /// <inheritdoc />
@@ -269,6 +269,7 @@ namespace RadioWash.Api.Migrations
                         .HasColumnType("text");
 
                     b.Property<DateTime?>("LastAttemptAt")
+                        .IsConcurrencyToken()
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("ProcessedAt")

--- a/api/Migrations/20260804130406_RestructureProcessedWebhookEventClaims.cs
+++ b/api/Migrations/20260804130406_RestructureProcessedWebhookEventClaims.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/api/Migrations/RadioWashDbContextModelSnapshot.cs
+++ b/api/Migrations/RadioWashDbContextModelSnapshot.cs
@@ -266,6 +266,7 @@ namespace RadioWash.Api.Migrations
                         .HasColumnType("text");
 
                     b.Property<DateTime?>("LastAttemptAt")
+                        .IsConcurrencyToken()
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("ProcessedAt")

--- a/api/Models/Domain/ProcessedWebhookEvent.cs
+++ b/api/Models/Domain/ProcessedWebhookEvent.cs
@@ -1,11 +1,24 @@
 namespace RadioWash.Api.Models.Domain;
 
+public enum WebhookEventStatus
+{
+  // A handler currently owns this event. A Processing row older than the stale threshold
+  // is treated as an abandoned claim (crashed instance) and can be taken over.
+  Processing = 0,
+  Succeeded = 1,
+  // Failed releases the claim: a Stripe redelivery or an internal retry may re-claim the
+  // event and attempt processing again.
+  Failed = 2
+}
+
 public class ProcessedWebhookEvent
 {
   public int Id { get; set; }
   public string EventId { get; set; } = null!;
   public string EventType { get; set; } = null!;
   public DateTime ProcessedAt { get; set; } = DateTime.UtcNow;
-  public bool IsSuccessful { get; set; } = true;
+  public WebhookEventStatus Status { get; set; } = WebhookEventStatus.Processing;
+  public DateTime? LastAttemptAt { get; set; }
+  public int AttemptCount { get; set; } = 1;
   public string? ErrorMessage { get; set; }
 }

--- a/api/Models/Domain/UserSubscription.cs
+++ b/api/Models/Domain/UserSubscription.cs
@@ -7,6 +7,55 @@ public static class SubscriptionStatus
   public const string PastDue = "past_due";
   public const string Trialing = "trialing";
   public const string Incomplete = "incomplete";
+  public const string Unpaid = "unpaid";
+  public const string Paused = "paused";
+}
+
+// Normalizes Stripe subscription statuses into the local vocabulary. Stripe can emit
+// statuses the app has no distinct behavior for (incomplete_expired); those collapse into
+// the closest local status instead of being written verbatim, so entitlement checks that
+// enumerate statuses stay exhaustive.
+public static class SubscriptionStatusMapper
+{
+  private static readonly HashSet<string> KnownStatuses = new(StringComparer.Ordinal)
+  {
+    SubscriptionStatus.Active,
+    SubscriptionStatus.Canceled,
+    SubscriptionStatus.PastDue,
+    SubscriptionStatus.Trialing,
+    SubscriptionStatus.Incomplete,
+    SubscriptionStatus.Unpaid,
+    SubscriptionStatus.Paused,
+  };
+
+  // Statuses that grant access to paid features.
+  public static bool IsEntitled(string? status) =>
+      status == SubscriptionStatus.Active || status == SubscriptionStatus.Trialing;
+
+  // Statuses under which sync configs must not keep running.
+  public static bool IsInactive(string? status) =>
+      status == SubscriptionStatus.Canceled
+      || status == SubscriptionStatus.PastDue
+      || status == SubscriptionStatus.Incomplete
+      || status == SubscriptionStatus.Unpaid
+      || status == SubscriptionStatus.Paused;
+
+  /// <summary>
+  /// Maps a raw Stripe status to the local status vocabulary. Returns false when the
+  /// status is unknown; the raw value is still returned so callers can persist it
+  /// (never lose Stripe's state) while logging the gap.
+  /// </summary>
+  public static bool TryMap(string rawStripeStatus, out string mapped)
+  {
+    if (rawStripeStatus == "incomplete_expired")
+    {
+      mapped = SubscriptionStatus.Canceled;
+      return true;
+    }
+
+    mapped = rawStripeStatus;
+    return KnownStatuses.Contains(rawStripeStatus);
+  }
 }
 
 public class UserSubscription

--- a/api/Models/Domain/WebhookRetry.cs
+++ b/api/Models/Domain/WebhookRetry.cs
@@ -6,7 +6,11 @@ public enum WebhookRetryStatus
   Processing = 1,
   Succeeded = 2,
   Failed = 3,
-  MaxRetriesExceeded = 4
+  MaxRetriesExceeded = 4,
+  // Another delivery path (Stripe redelivery, or a concurrent handler) processed the event
+  // before this retry ran — distinct from Succeeded so ops data doesn't claim this retry
+  // did the work.
+  Superseded = 5
 }
 
 public class WebhookRetry

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -115,6 +115,7 @@ builder.Services.AddScoped<IStripeHealthCheckService, StripeHealthCheckService>(
 
 // Stripe services
 builder.Services.AddScoped<Stripe.CustomerService>();
+builder.Services.AddScoped<Stripe.SubscriptionService>();
 
 // Idempotency service for webhook race condition prevention
 builder.Services.AddScoped<IIdempotencyService, DatabaseIdempotencyService>();

--- a/api/Services/BackgroundServices/WebhookTableRetentionBackgroundService.cs
+++ b/api/Services/BackgroundServices/WebhookTableRetentionBackgroundService.cs
@@ -100,7 +100,8 @@ public class WebhookTableRetentionBackgroundService : BackgroundService
             var deleted = await dbContext.WebhookRetries
                 .Where(wr => (wr.Status == WebhookRetryStatus.Succeeded
                               || wr.Status == WebhookRetryStatus.Failed
-                              || wr.Status == WebhookRetryStatus.MaxRetriesExceeded)
+                              || wr.Status == WebhookRetryStatus.MaxRetriesExceeded
+                              || wr.Status == WebhookRetryStatus.Superseded)
                               && wr.UpdatedAt < cutoff)
                 .OrderBy(wr => wr.UpdatedAt)
                 .Take(BatchSize)

--- a/api/Services/Exceptions/WebhookSignatureVerificationException.cs
+++ b/api/Services/Exceptions/WebhookSignatureVerificationException.cs
@@ -1,0 +1,13 @@
+namespace RadioWash.Api.Services.Exceptions;
+
+// Thrown when a Stripe webhook payload fails signature verification (tampered payload,
+// wrong signing secret, or a timestamp outside Stripe's tolerance window). The controller
+// maps this to HTTP 400 so Stripe treats the delivery as permanently rejected; every other
+// processing failure returns 500 so Stripe keeps redelivering.
+public class WebhookSignatureVerificationException : Exception
+{
+  public WebhookSignatureVerificationException(string message, Exception innerException)
+      : base(message, innerException)
+  {
+  }
+}

--- a/api/Services/Implementations/DatabaseIdempotencyService.cs
+++ b/api/Services/Implementations/DatabaseIdempotencyService.cs
@@ -7,10 +7,19 @@ using RadioWash.Api.Services.Interfaces;
 namespace RadioWash.Api.Services.Implementations;
 
 /// <summary>
-/// Database-backed idempotency service with application-level locking for webhook events
+/// Database-backed idempotency service with application-level locking for webhook events.
+/// A row acts as a processing claim: Processing rows are owned by a live handler, Succeeded
+/// rows are terminal, and Failed rows are re-claimable so Stripe redeliveries and internal
+/// retries can attempt the event again. Stale Processing rows (crashed instance) are taken
+/// over after a threshold. Takeovers are compare-and-swaps on Status (a concurrency token),
+/// so two claimants can never both win.
 /// </summary>
 public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 {
+    // A Processing claim older than this is assumed abandoned (the owning instance died
+    // mid-event) and may be taken over. Normal webhook processing completes in seconds.
+    private static readonly TimeSpan StaleClaimThreshold = TimeSpan.FromMinutes(15);
+
     private readonly RadioWashDbContext _dbContext;
     private readonly ILogger<DatabaseIdempotencyService> _logger;
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _eventLocks = new();
@@ -18,7 +27,7 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
     private volatile bool _disposed = false;
 
     public DatabaseIdempotencyService(
-        RadioWashDbContext dbContext, 
+        RadioWashDbContext dbContext,
         ILogger<DatabaseIdempotencyService> logger)
     {
         _dbContext = dbContext;
@@ -40,53 +49,107 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 
         try
         {
-            // First check if event already exists in database
             var existingEvent = await _dbContext.ProcessedWebhookEvents
-                .AsNoTracking()
                 .FirstOrDefaultAsync(e => e.EventId == eventId);
 
-            if (existingEvent != null)
+            if (existingEvent == null)
             {
-                _logger.LogInformation(
-                    "Webhook event {EventId} of type {EventType} has already been processed. Status: {IsSuccessful}",
-                    eventId, eventType, existingEvent.IsSuccessful ? "Success" : "Failed");
-                return false;
+                return await TryInsertClaimAsync(eventId, eventType);
             }
 
-            // Try to create the webhook event record to claim processing rights
-            var webhookEvent = new ProcessedWebhookEvent
+            switch (existingEvent.Status)
             {
-                EventId = eventId,
-                EventType = eventType,
-                ProcessedAt = DateTime.UtcNow,
-                IsSuccessful = false // Will be updated after successful processing
-            };
+                case WebhookEventStatus.Succeeded:
+                    _logger.LogInformation(
+                        "Webhook event {EventId} of type {EventType} has already been processed successfully",
+                        eventId, eventType);
+                    return false;
 
-            try
-            {
-                _dbContext.ProcessedWebhookEvents.Add(webhookEvent);
-                await _dbContext.SaveChangesAsync();
+                case WebhookEventStatus.Failed:
+                    return await TryTakeOverClaimAsync(existingEvent, "previous attempt failed");
 
-                _logger.LogInformation(
-                    "Successfully claimed processing rights for webhook event {EventId} of type {EventType}",
-                    eventId, eventType);
-                return true;
-            }
-            catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
-            {
-                // Another concurrent request already claimed this event
-                _logger.LogInformation(
-                    "Webhook event {EventId} of type {EventType} was already claimed by another concurrent request",
-                    eventId, eventType);
-                return false;
+                case WebhookEventStatus.Processing:
+                    var claimAge = DateTime.UtcNow - (existingEvent.LastAttemptAt ?? existingEvent.ProcessedAt);
+                    if (claimAge > StaleClaimThreshold)
+                    {
+                        return await TryTakeOverClaimAsync(existingEvent, $"stale claim ({claimAge.TotalMinutes:F0} min old)");
+                    }
+
+                    _logger.LogInformation(
+                        "Webhook event {EventId} of type {EventType} is currently being processed by another handler",
+                        eventId, eventType);
+                    return false;
+
+                default:
+                    return false;
             }
         }
         finally
         {
             eventLock.Release();
-            
+
             // Clean up the semaphore if no one else is waiting
             await CleanupEventLockIfUnusedAsync(eventId);
+        }
+    }
+
+    private async Task<bool> TryInsertClaimAsync(string eventId, string eventType)
+    {
+        var webhookEvent = new ProcessedWebhookEvent
+        {
+            EventId = eventId,
+            EventType = eventType,
+            ProcessedAt = DateTime.UtcNow,
+            Status = WebhookEventStatus.Processing,
+            LastAttemptAt = DateTime.UtcNow,
+            AttemptCount = 1
+        };
+
+        try
+        {
+            _dbContext.ProcessedWebhookEvents.Add(webhookEvent);
+            await _dbContext.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "Successfully claimed processing rights for webhook event {EventId} of type {EventType}",
+                eventId, eventType);
+            return true;
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            // Another concurrent request already claimed this event
+            _dbContext.Entry(webhookEvent).State = EntityState.Detached;
+            _logger.LogInformation(
+                "Webhook event {EventId} of type {EventType} was already claimed by another concurrent request",
+                eventId, eventType);
+            return false;
+        }
+    }
+
+    private async Task<bool> TryTakeOverClaimAsync(ProcessedWebhookEvent existingEvent, string reason)
+    {
+        // Status is a concurrency token, so this update only commits if the row still holds
+        // the status we read — a concurrent takeover loses with DbUpdateConcurrencyException.
+        existingEvent.Status = WebhookEventStatus.Processing;
+        existingEvent.LastAttemptAt = DateTime.UtcNow;
+        existingEvent.AttemptCount++;
+
+        try
+        {
+            await _dbContext.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "Re-claimed webhook event {EventId} for processing ({Reason}), attempt {AttemptCount}",
+                existingEvent.EventId, reason, existingEvent.AttemptCount);
+            return true;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            _dbContext.Entry(existingEvent).State = EntityState.Detached;
+            _logger.LogInformation(
+                "Webhook event {EventId} was re-claimed by another concurrent handler",
+                existingEvent.EventId);
+            return false;
         }
     }
 
@@ -104,9 +167,9 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 
             if (webhookEvent != null)
             {
-                webhookEvent.IsSuccessful = true;
+                webhookEvent.Status = WebhookEventStatus.Succeeded;
                 webhookEvent.ErrorMessage = null;
-                _dbContext.ProcessedWebhookEvents.Update(webhookEvent);
+                webhookEvent.ProcessedAt = DateTime.UtcNow;
                 await _dbContext.SaveChangesAsync();
 
                 _logger.LogInformation("Marked webhook event {EventId} as successfully processed", eventId);
@@ -137,12 +200,14 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 
             if (webhookEvent != null)
             {
-                webhookEvent.IsSuccessful = false;
+                // Failed releases the claim: Stripe redelivery (we return 500) or the
+                // internal retry loop can re-claim and try again.
+                webhookEvent.Status = WebhookEventStatus.Failed;
                 webhookEvent.ErrorMessage = errorMessage;
-                _dbContext.ProcessedWebhookEvents.Update(webhookEvent);
+                webhookEvent.LastAttemptAt = DateTime.UtcNow;
                 await _dbContext.SaveChangesAsync();
 
-                _logger.LogInformation("Marked webhook event {EventId} as failed with error: {ErrorMessage}", 
+                _logger.LogInformation("Marked webhook event {EventId} as failed with error: {ErrorMessage}",
                     eventId, errorMessage);
             }
             else
@@ -182,27 +247,17 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 
     private static bool IsUniqueConstraintViolation(DbUpdateException ex)
     {
-        // Check for SQL Server unique constraint violation
-        if (ex.InnerException?.Message?.Contains("duplicate key") == true ||
-            ex.InnerException?.Message?.Contains("UNIQUE constraint") == true ||
-            ex.InnerException?.Message?.Contains("unique constraint") == true)
+        // Postgres reports unique violations via SqlState 23505 — match on that, not on
+        // locale-dependent message text.
+        if (ex.InnerException is Npgsql.PostgresException pgEx)
         {
-            return true;
+            return pgEx.SqlState == "23505";
         }
 
-        // Check for SQLite unique constraint violation
-        if (ex.InnerException?.Message?.Contains("UNIQUE constraint failed") == true)
-        {
-            return true;
-        }
-
-        // Check for PostgreSQL unique constraint violation
-        if (ex.InnerException?.Message?.Contains("duplicate key value violates unique constraint") == true)
-        {
-            return true;
-        }
-
-        return false;
+        // Fallback for the EF InMemory provider used in unit tests, which surfaces unique
+        // index violations as a plain exception message.
+        return ex.InnerException?.Message?.Contains("unique", StringComparison.OrdinalIgnoreCase) == true
+            || ex.Message.Contains("same key", StringComparison.OrdinalIgnoreCase);
     }
 
     public void Dispose()

--- a/api/Services/Implementations/DatabaseIdempotencyService.cs
+++ b/api/Services/Implementations/DatabaseIdempotencyService.cs
@@ -7,12 +7,16 @@ using RadioWash.Api.Services.Interfaces;
 namespace RadioWash.Api.Services.Implementations;
 
 /// <summary>
-/// Database-backed idempotency service with application-level locking for webhook events.
-/// A row acts as a processing claim: Processing rows are owned by a live handler, Succeeded
-/// rows are terminal, and Failed rows are re-claimable so Stripe redeliveries and internal
-/// retries can attempt the event again. Stale Processing rows (crashed instance) are taken
-/// over after a threshold. Takeovers are compare-and-swaps on Status (a concurrency token),
-/// so two claimants can never both win.
+/// Database-backed idempotency service for webhook events. A row acts as a processing claim:
+/// Processing rows are owned by a live handler, Succeeded rows are terminal, and Failed rows
+/// are re-claimable so Stripe redeliveries and internal retries can attempt the event again.
+/// Stale Processing rows (crashed instance) are taken over after a threshold.
+///
+/// Cross-instance correctness comes from the database alone: the unique index on EventId
+/// arbitrates first claims, and takeovers are compare-and-swaps on the Status+LastAttemptAt
+/// concurrency tokens. The process-wide (static) semaphore map only serializes same-process
+/// duplicates to avoid needless DB round-trips. The overall guarantee is at-least-once
+/// processing — handlers must be idempotent.
 /// </summary>
 public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 {
@@ -20,10 +24,13 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
     // mid-event) and may be taken over. Normal webhook processing completes in seconds.
     private static readonly TimeSpan StaleClaimThreshold = TimeSpan.FromMinutes(15);
 
+    // Static: the service is scoped (one instance per request), so instance-level locks
+    // would never contend and would only manufacture false confidence.
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> EventLocks = new();
+    private static readonly SemaphoreSlim LockCleanupSemaphore = new(1, 1);
+
     private readonly RadioWashDbContext _dbContext;
     private readonly ILogger<DatabaseIdempotencyService> _logger;
-    private readonly ConcurrentDictionary<string, SemaphoreSlim> _eventLocks = new();
-    private readonly SemaphoreSlim _lockCleanupSemaphore = new(1, 1);
     private volatile bool _disposed = false;
 
     public DatabaseIdempotencyService(
@@ -42,7 +49,7 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
         }
 
         // Get or create a semaphore for this specific event ID
-        var eventLock = _eventLocks.GetOrAdd(eventId, _ => new SemaphoreSlim(1, 1));
+        var eventLock = EventLocks.GetOrAdd(eventId, _ => new SemaphoreSlim(1, 1));
 
         // Acquire the lock for this event
         await eventLock.WaitAsync();
@@ -128,8 +135,10 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 
     private async Task<bool> TryTakeOverClaimAsync(ProcessedWebhookEvent existingEvent, string reason)
     {
-        // Status is a concurrency token, so this update only commits if the row still holds
-        // the status we read — a concurrent takeover loses with DbUpdateConcurrencyException.
+        // Status and LastAttemptAt are concurrency tokens, so this update only commits if
+        // the row still holds the values we read — a concurrent takeover loses with
+        // DbUpdateConcurrencyException. LastAttemptAt is what makes the stale-Processing
+        // takeover a real CAS (Status alone would be Processing -> Processing, unchanged).
         existingEvent.Status = WebhookEventStatus.Processing;
         existingEvent.LastAttemptAt = DateTime.UtcNow;
         existingEvent.AttemptCount++;
@@ -222,17 +231,17 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
         }
     }
 
-    private async Task CleanupEventLockIfUnusedAsync(string eventId)
+    private static async Task CleanupEventLockIfUnusedAsync(string eventId)
     {
-        await _lockCleanupSemaphore.WaitAsync();
+        await LockCleanupSemaphore.WaitAsync();
         try
         {
-            if (_eventLocks.TryGetValue(eventId, out var semaphore))
+            if (EventLocks.TryGetValue(eventId, out var semaphore))
             {
                 // If no one is waiting and the current count is 1 (meaning it's available)
                 if (semaphore.CurrentCount == 1)
                 {
-                    if (_eventLocks.TryRemove(eventId, out var removedSemaphore))
+                    if (EventLocks.TryRemove(eventId, out var removedSemaphore))
                     {
                         removedSemaphore.Dispose();
                     }
@@ -241,7 +250,7 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
         }
         finally
         {
-            _lockCleanupSemaphore.Release();
+            LockCleanupSemaphore.Release();
         }
     }
 
@@ -262,20 +271,8 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-
+        // The lock structures are process-wide and shared across scoped instances, so
+        // disposing an instance must not tear them down; it only invalidates this instance.
         _disposed = true;
-
-        // Dispose all semaphores
-        foreach (var semaphore in _eventLocks.Values)
-        {
-            semaphore.Dispose();
-        }
-        _eventLocks.Clear();
-
-        _lockCleanupSemaphore.Dispose();
     }
 }

--- a/api/Services/Implementations/DatabaseIdempotencyService.cs
+++ b/api/Services/Implementations/DatabaseIdempotencyService.cs
@@ -122,7 +122,7 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
                 eventId, eventType);
             return true;
         }
-        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
         {
             // Another concurrent request already claimed this event
             _dbContext.Entry(webhookEvent).State = EntityState.Detached;
@@ -241,10 +241,15 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
                 // If no one is waiting and the current count is 1 (meaning it's available)
                 if (semaphore.CurrentCount == 1)
                 {
-                    if (EventLocks.TryRemove(eventId, out var removedSemaphore))
-                    {
-                        removedSemaphore.Dispose();
-                    }
+                    // Removed but deliberately NOT disposed: a concurrent claimant may have
+                    // GetOrAdd'd this same instance between the count check and the removal,
+                    // and disposing it under that claimant would throw ObjectDisposedException
+                    // from WaitAsync/Release. An undisposed SemaphoreSlim that never
+                    // materialized its WaitHandle holds no unmanaged state, so dropping the
+                    // reference is safe. If two claimants briefly hold different semaphores
+                    // for the same event, the DB unique index / concurrency tokens still
+                    // arbitrate correctly.
+                    EventLocks.TryRemove(eventId, out _);
                 }
             }
         }
@@ -252,21 +257,6 @@ public class DatabaseIdempotencyService : IIdempotencyService, IDisposable
         {
             LockCleanupSemaphore.Release();
         }
-    }
-
-    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
-    {
-        // Postgres reports unique violations via SqlState 23505 — match on that, not on
-        // locale-dependent message text.
-        if (ex.InnerException is Npgsql.PostgresException pgEx)
-        {
-            return pgEx.SqlState == "23505";
-        }
-
-        // Fallback for the EF InMemory provider used in unit tests, which surfaces unique
-        // index violations as a plain exception message.
-        return ex.InnerException?.Message?.Contains("unique", StringComparison.OrdinalIgnoreCase) == true
-            || ex.Message.Contains("same key", StringComparison.OrdinalIgnoreCase);
     }
 
     public void Dispose()

--- a/api/Services/Implementations/EventUtilityWrapper.cs
+++ b/api/Services/Implementations/EventUtilityWrapper.cs
@@ -9,4 +9,9 @@ public class EventUtilityWrapper : IEventUtility
   {
     return EventUtility.ConstructEvent(payload, signature, secret);
   }
+
+  public Event ParseEvent(string payload)
+  {
+    return EventUtility.ParseEvent(payload, throwOnApiVersionMismatch: false);
+  }
 }

--- a/api/Services/Implementations/StripePaymentService.cs
+++ b/api/Services/Implementations/StripePaymentService.cs
@@ -131,12 +131,22 @@ public class StripePaymentService : IPaymentService
     }
     catch (Exception processingEx)
     {
-      // Marking the event failed releases the idempotency claim so Stripe's redelivery
-      // (triggered by the controller's 500) can re-attempt it.
-      await _idempotencyService.MarkEventFailedAsync(stripeEvent.Id, processingEx.Message);
-
+      // Log the original failure first — if releasing the claim below also fails (DB down),
+      // that secondary error must not mask this one.
       _logger.LogError(processingEx, "Failed to process webhook event {EventId} of type {EventType}: {ErrorMessage}",
           stripeEvent.Id, stripeEvent.Type, processingEx.Message);
+
+      try
+      {
+        // Marking the event failed releases the idempotency claim so Stripe's redelivery
+        // (triggered by the controller's 500) can re-attempt it.
+        await _idempotencyService.MarkEventFailedAsync(stripeEvent.Id, processingEx.Message);
+      }
+      catch (Exception markEx)
+      {
+        // Claim stays Processing; the stale-claim takeover unblocks it after 15 minutes.
+        _logger.LogError(markEx, "Failed to release idempotency claim for webhook event {EventId}", stripeEvent.Id);
+      }
 
       // Schedule retry if the error is retryable
       if (_webhookRetryService.IsRetryableError(processingEx))

--- a/api/Services/Implementations/StripePaymentService.cs
+++ b/api/Services/Implementations/StripePaymentService.cs
@@ -1,7 +1,5 @@
+using RadioWash.Api.Services.Exceptions;
 using RadioWash.Api.Services.Interfaces;
-using RadioWash.Api.Models.Domain;
-using RadioWash.Api.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
 using Stripe;
 using Stripe.Checkout;
 
@@ -10,10 +8,7 @@ namespace RadioWash.Api.Services.Implementations;
 public class StripePaymentService : IPaymentService
 {
   private readonly IConfiguration _configuration;
-  private readonly ISubscriptionService _subscriptionService;
   private readonly IEventUtility _eventUtility;
-  private readonly RadioWashDbContext _dbContext;
-  private readonly CustomerService _customerService;
   private readonly IIdempotencyService _idempotencyService;
   private readonly IWebhookRetryService _webhookRetryService;
   private readonly IWebhookProcessor _webhookProcessor;
@@ -21,20 +16,14 @@ public class StripePaymentService : IPaymentService
 
   public StripePaymentService(
       IConfiguration configuration,
-      ISubscriptionService subscriptionService,
       IEventUtility eventUtility,
-      RadioWashDbContext dbContext,
-      CustomerService customerService,
       IIdempotencyService idempotencyService,
       IWebhookRetryService webhookRetryService,
       IWebhookProcessor webhookProcessor,
       ILogger<StripePaymentService> logger)
   {
     _configuration = configuration;
-    _subscriptionService = subscriptionService;
     _eventUtility = eventUtility;
-    _dbContext = dbContext;
-    _customerService = customerService;
     _idempotencyService = idempotencyService;
     _webhookRetryService = webhookRetryService;
     _webhookProcessor = webhookProcessor;
@@ -97,83 +86,85 @@ public class StripePaymentService : IPaymentService
   public async Task HandleWebhookAsync(string payload, string signature)
   {
     var webhookSecret = _configuration["Stripe:WebhookSecret"];
-    
+
     if (string.IsNullOrEmpty(webhookSecret))
     {
       _logger.LogError("Stripe webhook secret is not configured");
       throw new InvalidOperationException("Stripe webhook secret is not configured");
     }
 
+    Event stripeEvent;
     try
     {
-      var stripeEvent = _eventUtility.ConstructEvent(payload, signature, webhookSecret);
-
-      _logger.LogInformation("Processing Stripe webhook event: {EventType} with ID {EventId}", 
-          stripeEvent.Type, stripeEvent.Id);
-
-      // Use idempotency service to ensure only one concurrent request processes this event
-      var shouldProcess = await _idempotencyService.TryProcessEventAsync(stripeEvent.Id, stripeEvent.Type);
-      
-      if (!shouldProcess)
-      {
-        _logger.LogInformation("Webhook event {EventId} of type {EventType} has already been processed or claimed by another request", 
-            stripeEvent.Id, stripeEvent.Type);
-        return;
-      }
-
-      try
-      {
-        // Use the webhook processor for actual event processing
-        await _webhookProcessor.ProcessWebhookAsync(payload, signature);
-
-        // Mark event as successfully processed
-        await _idempotencyService.MarkEventSuccessfulAsync(stripeEvent.Id);
-
-        _logger.LogInformation("Successfully processed webhook event {EventId} of type {EventType}", 
-            stripeEvent.Id, stripeEvent.Type);
-      }
-      catch (Exception processingEx)
-      {
-        // Mark event as failed
-        await _idempotencyService.MarkEventFailedAsync(stripeEvent.Id, processingEx.Message);
-
-        _logger.LogError(processingEx, "Failed to process webhook event {EventId} of type {EventType}: {ErrorMessage}", 
-            stripeEvent.Id, stripeEvent.Type, processingEx.Message);
-
-        // Schedule retry if the error is retryable
-        if (_webhookRetryService.IsRetryableError(processingEx))
-        {
-          try
-          {
-            await _webhookRetryService.ScheduleRetryAsync(
-              stripeEvent.Id, 
-              stripeEvent.Type, 
-              payload, 
-              signature, 
-              processingEx.Message);
-            
-            _logger.LogInformation("Scheduled retry for webhook event {EventId} due to retryable error", stripeEvent.Id);
-          }
-          catch (Exception retryEx)
-          {
-            _logger.LogError(retryEx, "Failed to schedule retry for webhook event {EventId}: {RetryError}", 
-              stripeEvent.Id, retryEx.Message);
-          }
-        }
-        else
-        {
-          _logger.LogWarning("Webhook event {EventId} failed with non-retryable error: {ErrorMessage}", 
-            stripeEvent.Id, processingEx.Message);
-        }
-        
-        throw;
-      }
+      stripeEvent = _eventUtility.ConstructEvent(payload, signature, webhookSecret);
     }
     catch (StripeException ex)
     {
+      // Only verification/parsing of the incoming payload maps to a permanent rejection
+      // (HTTP 400). StripeExceptions thrown during processing must NOT land here — they
+      // propagate below so Stripe redelivers.
       _logger.LogError(ex, "Stripe webhook signature verification failed: {Message}", ex.Message);
+      throw new WebhookSignatureVerificationException("Stripe webhook signature verification failed", ex);
+    }
+
+    _logger.LogInformation("Processing Stripe webhook event: {EventType} with ID {EventId}",
+        stripeEvent.Type, stripeEvent.Id);
+
+    // Use idempotency service to ensure only one concurrent request processes this event
+    var shouldProcess = await _idempotencyService.TryProcessEventAsync(stripeEvent.Id, stripeEvent.Type);
+
+    if (!shouldProcess)
+    {
+      _logger.LogInformation("Webhook event {EventId} of type {EventType} has already been processed or claimed by another request",
+          stripeEvent.Id, stripeEvent.Type);
+      return;
+    }
+
+    try
+    {
+      await _webhookProcessor.ProcessEventAsync(stripeEvent);
+
+      await _idempotencyService.MarkEventSuccessfulAsync(stripeEvent.Id);
+
+      _logger.LogInformation("Successfully processed webhook event {EventId} of type {EventType}",
+          stripeEvent.Id, stripeEvent.Type);
+    }
+    catch (Exception processingEx)
+    {
+      // Marking the event failed releases the idempotency claim so Stripe's redelivery
+      // (triggered by the controller's 500) can re-attempt it.
+      await _idempotencyService.MarkEventFailedAsync(stripeEvent.Id, processingEx.Message);
+
+      _logger.LogError(processingEx, "Failed to process webhook event {EventId} of type {EventType}: {ErrorMessage}",
+          stripeEvent.Id, stripeEvent.Type, processingEx.Message);
+
+      // Schedule retry if the error is retryable
+      if (_webhookRetryService.IsRetryableError(processingEx))
+      {
+        try
+        {
+          await _webhookRetryService.ScheduleRetryAsync(
+            stripeEvent.Id,
+            stripeEvent.Type,
+            payload,
+            signature,
+            processingEx.Message);
+
+          _logger.LogInformation("Scheduled retry for webhook event {EventId} due to retryable error", stripeEvent.Id);
+        }
+        catch (Exception retryEx)
+        {
+          _logger.LogError(retryEx, "Failed to schedule retry for webhook event {EventId}: {RetryError}",
+            stripeEvent.Id, retryEx.Message);
+        }
+      }
+      else
+      {
+        _logger.LogWarning("Webhook event {EventId} failed with non-retryable error: {ErrorMessage}",
+          stripeEvent.Id, processingEx.Message);
+      }
+
       throw;
     }
   }
-
 }

--- a/api/Services/Implementations/StripeWebhookProcessor.cs
+++ b/api/Services/Implementations/StripeWebhookProcessor.cs
@@ -86,15 +86,17 @@ public class StripeWebhookProcessor : IWebhookProcessor
 
     // Handles both customer.subscription.created and .updated: SyncFromStripeAsync upserts
     // keyed on the Stripe subscription id, so ordering between the two doesn't matter.
+    // The event's embedded subscription is only used as a pointer — the state written comes
+    // from a fresh fetch (see SyncSubscriptionFromStripeAsync), because a delayed redelivery
+    // of an old `updated` event (status active) after cancellation would otherwise
+    // resurrect the canceled subscription.
     private async Task HandleSubscriptionChangedAsync(Event stripeEvent)
     {
         var subscription = stripeEvent.Data.Object as Stripe.Subscription
             ?? throw new InvalidOperationException(
                 $"Event {stripeEvent.Id} ({stripeEvent.Type}) has no subscription object");
 
-        await _subscriptionService.SyncFromStripeAsync(
-            subscription,
-            () => ResolveUserIdFromCustomerAsync(subscription.CustomerId, subscription.Id));
+        await SyncSubscriptionFromStripeAsync(subscription.Id);
     }
 
     private async Task HandleSubscriptionDeletedAsync(Event stripeEvent)
@@ -154,11 +156,13 @@ public class StripeWebhookProcessor : IWebhookProcessor
         await SyncSubscriptionFromStripeAsync(subscriptionId);
     }
 
-    // Invoice events carry no subscription state, only a pointer — so always fetch the
-    // subscription's CURRENT state from Stripe and upsert that. Deriving a status from the
-    // event type instead (e.g. payment_succeeded => active) breaks on delayed redeliveries:
-    // Stripe can redeliver an old invoice event for up to 3 days, and forcing "active" then
-    // would resurrect a subscription that was since canceled.
+    // Events are treated as pointers, never as state: always fetch the subscription's
+    // CURRENT state from Stripe and upsert that. Applying an event's embedded snapshot (or
+    // deriving a status from the event type, e.g. payment_succeeded => active) breaks on
+    // delayed redeliveries: Stripe can redeliver an old event for up to 3 days, and a stale
+    // "active" then would resurrect a subscription that was since canceled. Canceled
+    // subscriptions stay retrievable via GetAsync, so the fetch works for every lifecycle
+    // stage this processor handles.
     private async Task SyncSubscriptionFromStripeAsync(string subscriptionId)
     {
         var stripeSubscription = await _stripeSubscriptionService.GetAsync(subscriptionId);

--- a/api/Services/Implementations/StripeWebhookProcessor.cs
+++ b/api/Services/Implementations/StripeWebhookProcessor.cs
@@ -132,7 +132,7 @@ public class StripeWebhookProcessor : IWebhookProcessor
         _logger.LogWarning("Payment failed for subscription {SubscriptionId} from invoice {InvoiceId}",
             subscriptionId, invoice.Id);
 
-        await UpdateOrSyncSubscriptionStatusAsync(subscriptionId, SubscriptionStatus.PastDue);
+        await SyncSubscriptionFromStripeAsync(subscriptionId);
     }
 
     private async Task HandlePaymentSucceededAsync(Event stripeEvent)
@@ -151,30 +151,20 @@ public class StripeWebhookProcessor : IWebhookProcessor
         _logger.LogInformation("Payment succeeded for subscription {SubscriptionId}, invoice {InvoiceId}",
             subscriptionId, invoice.Id);
 
-        // Reset to active in case the subscription was past_due/incomplete.
-        await UpdateOrSyncSubscriptionStatusAsync(subscriptionId, SubscriptionStatus.Active);
+        await SyncSubscriptionFromStripeAsync(subscriptionId);
     }
 
-    // Updates the local status; when no local row exists (invoice event arrived before the
-    // subscription event), fetches the subscription from Stripe and creates the row from its
-    // real current state instead of failing.
-    private async Task UpdateOrSyncSubscriptionStatusAsync(string subscriptionId, string status)
+    // Invoice events carry no subscription state, only a pointer — so always fetch the
+    // subscription's CURRENT state from Stripe and upsert that. Deriving a status from the
+    // event type instead (e.g. payment_succeeded => active) breaks on delayed redeliveries:
+    // Stripe can redeliver an old invoice event for up to 3 days, and forcing "active" then
+    // would resurrect a subscription that was since canceled.
+    private async Task SyncSubscriptionFromStripeAsync(string subscriptionId)
     {
-        var local = await _subscriptionService.GetByStripeSubscriptionIdAsync(subscriptionId);
-        if (local == null)
-        {
-            _logger.LogInformation(
-                "No local record for subscription {SubscriptionId}; fetching from Stripe to create it",
-                subscriptionId);
-
-            var stripeSubscription = await _stripeSubscriptionService.GetAsync(subscriptionId);
-            await _subscriptionService.SyncFromStripeAsync(
-                stripeSubscription,
-                () => ResolveUserIdFromCustomerAsync(stripeSubscription.CustomerId, subscriptionId));
-            return;
-        }
-
-        await _subscriptionService.UpdateSubscriptionStatusAsync(subscriptionId, status);
+        var stripeSubscription = await _stripeSubscriptionService.GetAsync(subscriptionId);
+        await _subscriptionService.SyncFromStripeAsync(
+            stripeSubscription,
+            () => ResolveUserIdFromCustomerAsync(stripeSubscription.CustomerId, subscriptionId));
     }
 
     // Fallback userId resolution for subscriptions without userId metadata (e.g. created

--- a/api/Services/Implementations/StripeWebhookProcessor.cs
+++ b/api/Services/Implementations/StripeWebhookProcessor.cs
@@ -1,5 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using RadioWash.Api.Infrastructure.Data;
 using RadioWash.Api.Models.Domain;
 using RadioWash.Api.Services.Interfaces;
 using Stripe;
@@ -11,42 +9,29 @@ public class StripeWebhookProcessor : IWebhookProcessor
 {
     private readonly IConfiguration _configuration;
     private readonly ISubscriptionService _subscriptionService;
-    private readonly IEventUtility _eventUtility;
-    private readonly RadioWashDbContext _dbContext;
     private readonly CustomerService _customerService;
+    private readonly Stripe.SubscriptionService _stripeSubscriptionService;
     private readonly ILogger<StripeWebhookProcessor> _logger;
 
     public StripeWebhookProcessor(
         IConfiguration configuration,
         ISubscriptionService subscriptionService,
-        IEventUtility eventUtility,
-        RadioWashDbContext dbContext,
         CustomerService customerService,
+        Stripe.SubscriptionService stripeSubscriptionService,
         ILogger<StripeWebhookProcessor> logger)
     {
         _configuration = configuration;
         _subscriptionService = subscriptionService;
-        _eventUtility = eventUtility;
-        _dbContext = dbContext;
         _customerService = customerService;
+        _stripeSubscriptionService = stripeSubscriptionService;
         _logger = logger;
 
         StripeConfiguration.ApiKey = _configuration["Stripe:SecretKey"];
     }
 
-    public async Task ProcessWebhookAsync(string payload, string signature)
+    public async Task ProcessEventAsync(Event stripeEvent)
     {
-        var webhookSecret = _configuration["Stripe:WebhookSecret"];
-        
-        if (string.IsNullOrEmpty(webhookSecret))
-        {
-            _logger.LogError("Stripe webhook secret is not configured");
-            throw new InvalidOperationException("Stripe webhook secret is not configured");
-        }
-
-        var stripeEvent = _eventUtility.ConstructEvent(payload, signature, webhookSecret);
-
-        _logger.LogInformation("Processing Stripe webhook event: {EventType} with ID {EventId}", 
+        _logger.LogInformation("Processing Stripe webhook event: {EventType} with ID {EventId}",
             stripeEvent.Type, stripeEvent.Id);
 
         switch (stripeEvent.Type)
@@ -55,10 +40,8 @@ public class StripeWebhookProcessor : IWebhookProcessor
                 await HandleCheckoutCompletedAsync(stripeEvent);
                 break;
             case "customer.subscription.created":
-                await HandleSubscriptionCreatedAsync(stripeEvent);
-                break;
             case "customer.subscription.updated":
-                await HandleSubscriptionUpdatedAsync(stripeEvent);
+                await HandleSubscriptionChangedAsync(stripeEvent);
                 break;
             case "customer.subscription.deleted":
                 await HandleSubscriptionDeletedAsync(stripeEvent);
@@ -74,338 +57,164 @@ public class StripeWebhookProcessor : IWebhookProcessor
                 break;
         }
 
-        _logger.LogInformation("Successfully processed webhook event {EventId} of type {EventType}", 
+        _logger.LogInformation("Successfully processed webhook event {EventId} of type {EventType}",
             stripeEvent.Id, stripeEvent.Type);
     }
 
-    private async Task HandleCheckoutCompletedAsync(Event stripeEvent)
+    private Task HandleCheckoutCompletedAsync(Event stripeEvent)
     {
+        // The subscription itself is handled by customer.subscription.created/updated;
+        // checkout completion is informational only.
         var session = stripeEvent.Data.Object as Session;
         if (session == null)
         {
-            _logger.LogWarning("Checkout completed event received but session object is null");
-            return;
+            _logger.LogWarning("Checkout completed event {EventId} has no session object", stripeEvent.Id);
+            return Task.CompletedTask;
         }
 
-        try
+        if (session.Metadata?.TryGetValue("userId", out var userIdStr) == true && int.TryParse(userIdStr, out var userId))
         {
-            if (session.Metadata?.TryGetValue("userId", out var userIdStr) == true && int.TryParse(userIdStr, out var userId))
-            {
-                _logger.LogInformation("Checkout completed for user {UserId}, session {SessionId}", userId, session.Id);
-                // The subscription will be handled by the subscription.created event
-                // For now, we just log the successful checkout
-            }
-            else
-            {
-                _logger.LogWarning("Checkout completed for session {SessionId} but no valid userId found in metadata", session.Id);
-            }
+            _logger.LogInformation("Checkout completed for user {UserId}, session {SessionId}", userId, session.Id);
         }
-        catch (Exception ex)
+        else
         {
-            _logger.LogError(ex, "Error processing checkout completed event for session {SessionId}", session.Id);
-            throw;
+            _logger.LogWarning("Checkout completed for session {SessionId} but no valid userId found in metadata", session.Id);
         }
 
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
-    private async Task HandleSubscriptionUpdatedAsync(Event stripeEvent)
+    // Handles both customer.subscription.created and .updated: SyncFromStripeAsync upserts
+    // keyed on the Stripe subscription id, so ordering between the two doesn't matter.
+    private async Task HandleSubscriptionChangedAsync(Event stripeEvent)
     {
-        var subscription = stripeEvent.Data.Object as Stripe.Subscription;
-        if (subscription == null) return;
+        var subscription = stripeEvent.Data.Object as Stripe.Subscription
+            ?? throw new InvalidOperationException(
+                $"Event {stripeEvent.Id} ({stripeEvent.Type}) has no subscription object");
 
-        var existing = await _dbContext.UserSubscriptions
-            .AsNoTracking()
-            .FirstOrDefaultAsync(us => us.StripeSubscriptionId == subscription.Id);
-        var previousStatus = existing?.Status;
-        var userId = existing?.UserId;
-
-        await _subscriptionService.UpdateSubscriptionStatusAsync(subscription.Id, subscription.Status);
-
-        if (userId.HasValue
-            && subscription.Status == SubscriptionStatus.Active
-            && IsInactiveStatus(previousStatus))
-        {
-            await _subscriptionService.ReactivateSyncConfigsAsync(userId.Value);
-        }
-
-        // Get period dates from subscription items (v49 compatibility)
-        DateTime? currentPeriodStart = null;
-        DateTime? currentPeriodEnd = null;
-
-        try
-        {
-            if (subscription.Items?.Data?.Any() == true)
-            {
-                // For single-item subscriptions, use the first item's period dates
-                // For multi-item subscriptions, use the latest period end
-                var subscriptionItem = subscription.Items.Data.First();
-                currentPeriodStart = subscriptionItem.CurrentPeriodStart;
-                currentPeriodEnd = subscription.Items.Data.Max(x => x.CurrentPeriodEnd);
-
-                _logger.LogInformation("Retrieved period dates from subscription items for {SubscriptionId}: Start={Start}, End={End}",
-                    subscription.Id, currentPeriodStart, currentPeriodEnd);
-            }
-            else
-            {
-                _logger.LogWarning("No subscription items found for subscription {SubscriptionId}, cannot update period dates",
-                    subscription.Id);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving period dates from subscription items for {SubscriptionId}",
-                subscription.Id);
-        }
-
-        // Only update dates if we successfully retrieved them
-        if (currentPeriodStart.HasValue && currentPeriodEnd.HasValue)
-        {
-            await _subscriptionService.UpdateSubscriptionDatesAsync(
-                subscription.Id,
-                currentPeriodStart.Value,
-                currentPeriodEnd.Value
-            );
-        }
-
-        _logger.LogInformation("Updated subscription {SubscriptionId} status to {Status}",
-            subscription.Id, subscription.Status);
+        await _subscriptionService.SyncFromStripeAsync(
+            subscription,
+            () => ResolveUserIdFromCustomerAsync(subscription.CustomerId, subscription.Id));
     }
 
     private async Task HandleSubscriptionDeletedAsync(Event stripeEvent)
     {
-        var subscription = stripeEvent.Data.Object as Stripe.Subscription;
-        if (subscription == null) return;
+        var subscription = stripeEvent.Data.Object as Stripe.Subscription
+            ?? throw new InvalidOperationException(
+                $"Event {stripeEvent.Id} (customer.subscription.deleted) has no subscription object");
 
-        await _subscriptionService.UpdateSubscriptionStatusAsync(subscription.Id, "canceled");
+        var local = await _subscriptionService.GetByStripeSubscriptionIdAsync(subscription.Id);
+        if (local == null)
+        {
+            // Nothing to cancel locally; the reconciliation job owns any remaining drift.
+            _logger.LogWarning("Subscription {SubscriptionId} deleted on Stripe but no local record exists", subscription.Id);
+            return;
+        }
+
+        await _subscriptionService.UpdateSubscriptionStatusAsync(subscription.Id, SubscriptionStatus.Canceled);
 
         _logger.LogInformation("Subscription {SubscriptionId} deleted", subscription.Id);
     }
 
     private async Task HandlePaymentFailedAsync(Event stripeEvent)
     {
-        var invoice = stripeEvent.Data.Object as Invoice;
-        if (invoice == null) return;
+        var invoice = stripeEvent.Data.Object as Invoice
+            ?? throw new InvalidOperationException(
+                $"Event {stripeEvent.Id} (invoice.payment_failed) has no invoice object");
 
-        // Handle v49 compatibility - get subscription ID from RawJObject if direct property not available
-        string? subscriptionId = null;
-
-        try
+        var subscriptionId = GetSubscriptionIdFromInvoice(invoice);
+        if (string.IsNullOrEmpty(subscriptionId))
         {
-            // Try to get subscription ID from RawJObject (always available in webhook events)
-            var subscriptionValue = invoice.RawJObject?["subscription"];
-            if (subscriptionValue != null)
-            {
-                subscriptionId = subscriptionValue.Type == Newtonsoft.Json.Linq.JTokenType.String
-                    ? subscriptionValue.ToString()
-                    : subscriptionValue["id"]?.ToString();
-            }
-
-            if (!string.IsNullOrEmpty(subscriptionId))
-            {
-                _logger.LogInformation("Retrieved subscription ID {SubscriptionId} from invoice {InvoiceId} webhook",
-                    subscriptionId, invoice.Id);
-            }
-            else
-            {
-                _logger.LogWarning("No subscription reference found in invoice {InvoiceId} webhook payload", invoice.Id);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error accessing subscription information from invoice {InvoiceId} webhook", invoice.Id);
-        }
-
-        if (!string.IsNullOrEmpty(subscriptionId))
-        {
-            try
-            {
-                await _subscriptionService.UpdateSubscriptionStatusAsync(subscriptionId, "past_due");
-                _logger.LogWarning("Payment failed for subscription {SubscriptionId} from invoice {InvoiceId}",
-                    subscriptionId, invoice.Id);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to update subscription {SubscriptionId} status after payment failure for invoice {InvoiceId}",
-                    subscriptionId, invoice.Id);
-                throw;
-            }
-        }
-        else
-        {
-            _logger.LogWarning("Could not determine subscription ID for failed payment on invoice {InvoiceId}", invoice.Id);
-        }
-    }
-
-    private async Task HandleSubscriptionCreatedAsync(Event stripeEvent)
-    {
-        var subscription = stripeEvent.Data.Object as Stripe.Subscription;
-        if (subscription == null)
-        {
-            _logger.LogWarning("Subscription created event received but subscription object is null");
+            _logger.LogInformation("Payment failed for invoice {InvoiceId} (not subscription-related)", invoice.Id);
             return;
         }
 
-        try
-        {
-            _logger.LogInformation("Processing subscription creation for {SubscriptionId}", subscription.Id);
+        _logger.LogWarning("Payment failed for subscription {SubscriptionId} from invoice {InvoiceId}",
+            subscriptionId, invoice.Id);
 
-            // Get the price ID from the subscription items
-            if (subscription.Items?.Data?.Any() != true)
-            {
-                _logger.LogWarning("Subscription {SubscriptionId} has no items", subscription.Id);
-                return;
-            }
-
-            var priceId = subscription.Items.Data.First().Price.Id;
-            _logger.LogInformation("Found price ID {PriceId} for subscription {SubscriptionId}", priceId, subscription.Id);
-
-            // Find the local plan by Stripe price ID
-            var plan = await _subscriptionService.GetPlanByStripePriceIdAsync(priceId);
-            if (plan == null)
-            {
-                _logger.LogError("No local plan found for Stripe price ID {PriceId}", priceId);
-                return;
-            }
-
-            // Get user ID from subscription metadata
-            int? userId = null;
-            
-            try
-            {
-                // Try to get user ID from subscription metadata first
-                if (subscription.Metadata?.TryGetValue("userId", out var userIdStr) == true && 
-                    int.TryParse(userIdStr, out var parsedUserId))
-                {
-                    userId = parsedUserId;
-                    _logger.LogInformation("Found user ID {UserId} in subscription metadata for subscription {SubscriptionId}", 
-                        userId, subscription.Id);
-                }
-                else
-                {
-                    // Fallback: try customer metadata (for existing subscriptions)
-                    var customer = await _customerService.GetAsync(subscription.CustomerId);
-                    
-                    if (customer?.Metadata?.TryGetValue("userId", out userIdStr) == true && 
-                        int.TryParse(userIdStr, out parsedUserId))
-                    {
-                        userId = parsedUserId;
-                        _logger.LogInformation("Found user ID {UserId} in customer metadata for subscription {SubscriptionId}", 
-                            userId, subscription.Id);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to retrieve user ID for subscription {SubscriptionId}", subscription.Id);
-            }
-
-            if (!userId.HasValue)
-            {
-                _logger.LogError("Could not determine user ID for subscription {SubscriptionId}", subscription.Id);
-                return;
-            }
-
-            // Use transaction only for the database write operation to ensure atomicity
-            using var transaction = await _dbContext.Database.BeginTransactionAsync();
-            
-            try
-            {
-                // Create the subscription record within the transaction
-                await _subscriptionService.CreateSubscriptionAsync(
-                    userId.Value, 
-                    plan.Id, 
-                    subscription.Id, 
-                    subscription.CustomerId);
-
-                // Commit the transaction if subscription creation succeeded
-                await transaction.CommitAsync();
-                
-                _logger.LogInformation("Successfully created subscription record for user {UserId}, subscription {SubscriptionId}", 
-                    userId, subscription.Id);
-            }
-            catch (Exception dbEx)
-            {
-                // Rollback the transaction on database operation failure
-                await transaction.RollbackAsync();
-                _logger.LogError(dbEx, "Failed to create subscription record for user {UserId}, subscription {SubscriptionId}. Transaction rolled back.", 
-                    userId, subscription.Id);
-                throw;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error processing subscription created event for subscription {SubscriptionId}", subscription.Id);
-            throw;
-        }
+        await UpdateOrSyncSubscriptionStatusAsync(subscriptionId, SubscriptionStatus.PastDue);
     }
 
     private async Task HandlePaymentSucceededAsync(Event stripeEvent)
     {
-        var invoice = stripeEvent.Data.Object as Invoice;
-        if (invoice == null)
+        var invoice = stripeEvent.Data.Object as Invoice
+            ?? throw new InvalidOperationException(
+                $"Event {stripeEvent.Id} (invoice.payment_succeeded) has no invoice object");
+
+        var subscriptionId = GetSubscriptionIdFromInvoice(invoice);
+        if (string.IsNullOrEmpty(subscriptionId))
         {
-            _logger.LogWarning("Payment succeeded event received but invoice object is null");
+            _logger.LogInformation("Payment succeeded for invoice {InvoiceId} (not subscription-related)", invoice.Id);
             return;
         }
 
+        _logger.LogInformation("Payment succeeded for subscription {SubscriptionId}, invoice {InvoiceId}",
+            subscriptionId, invoice.Id);
+
+        // Reset to active in case the subscription was past_due/incomplete.
+        await UpdateOrSyncSubscriptionStatusAsync(subscriptionId, SubscriptionStatus.Active);
+    }
+
+    // Updates the local status; when no local row exists (invoice event arrived before the
+    // subscription event), fetches the subscription from Stripe and creates the row from its
+    // real current state instead of failing.
+    private async Task UpdateOrSyncSubscriptionStatusAsync(string subscriptionId, string status)
+    {
+        var local = await _subscriptionService.GetByStripeSubscriptionIdAsync(subscriptionId);
+        if (local == null)
+        {
+            _logger.LogInformation(
+                "No local record for subscription {SubscriptionId}; fetching from Stripe to create it",
+                subscriptionId);
+
+            var stripeSubscription = await _stripeSubscriptionService.GetAsync(subscriptionId);
+            await _subscriptionService.SyncFromStripeAsync(
+                stripeSubscription,
+                () => ResolveUserIdFromCustomerAsync(stripeSubscription.CustomerId, subscriptionId));
+            return;
+        }
+
+        await _subscriptionService.UpdateSubscriptionStatusAsync(subscriptionId, status);
+    }
+
+    // Fallback userId resolution for subscriptions without userId metadata (e.g. created
+    // outside the app's checkout flow): look at the Stripe customer's metadata.
+    private async Task<int?> ResolveUserIdFromCustomerAsync(string customerId, string subscriptionId)
+    {
         try
         {
-            // Get subscription ID from invoice
-            string? subscriptionId = null;
-
-            try
+            var customer = await _customerService.GetAsync(customerId);
+            if (customer?.Metadata?.TryGetValue("userId", out var userIdStr) == true
+                && int.TryParse(userIdStr, out var userId))
             {
-                var subscriptionValue = invoice.RawJObject?["subscription"];
-                if (subscriptionValue != null)
-                {
-                    subscriptionId = subscriptionValue.Type == Newtonsoft.Json.Linq.JTokenType.String
-                        ? subscriptionValue.ToString()
-                        : subscriptionValue["id"]?.ToString();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to extract subscription ID from invoice {InvoiceId}", invoice.Id);
-            }
-
-            if (!string.IsNullOrEmpty(subscriptionId))
-            {
-                _logger.LogInformation("Payment succeeded for subscription {SubscriptionId}, invoice {InvoiceId}",
-                    subscriptionId, invoice.Id);
-
-                var existing = await _dbContext.UserSubscriptions
-                    .AsNoTracking()
-                    .FirstOrDefaultAsync(us => us.StripeSubscriptionId == subscriptionId);
-                var previousStatus = existing?.Status;
-                var userId = existing?.UserId;
-
-                // Update subscription status to active (in case it was incomplete or past_due)
-                await _subscriptionService.UpdateSubscriptionStatusAsync(subscriptionId, SubscriptionStatus.Active);
-
-                if (userId.HasValue && IsInactiveStatus(previousStatus))
-                {
-                    await _subscriptionService.ReactivateSyncConfigsAsync(userId.Value);
-                }
-            }
-            else
-            {
-                _logger.LogInformation("Payment succeeded for invoice {InvoiceId} (not subscription-related)", invoice.Id);
+                _logger.LogInformation(
+                    "Found user ID {UserId} in customer metadata for subscription {SubscriptionId}",
+                    userId, subscriptionId);
+                return userId;
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing payment succeeded event for invoice {InvoiceId}", invoice.Id);
-            throw;
+            _logger.LogWarning(ex, "Failed to look up customer {CustomerId} for subscription {SubscriptionId}",
+                customerId, subscriptionId);
         }
 
-        await Task.CompletedTask;
+        return null;
     }
 
-    private static bool IsInactiveStatus(string? status)
+    private string? GetSubscriptionIdFromInvoice(Invoice invoice)
     {
-        return status == SubscriptionStatus.PastDue
-            || status == SubscriptionStatus.Canceled
-            || status == SubscriptionStatus.Incomplete;
+        // v49 compatibility: the subscription reference is only reliably present in the raw
+        // webhook JSON, either as a string id or an expanded object.
+        // A missing key and an explicit JSON null both mean "not subscription-related".
+        var subscriptionValue = invoice.RawJObject?["subscription"];
+        if (subscriptionValue == null || subscriptionValue.Type == Newtonsoft.Json.Linq.JTokenType.Null)
+        {
+            return null;
+        }
+
+        return subscriptionValue.Type == Newtonsoft.Json.Linq.JTokenType.String
+            ? subscriptionValue.ToString()
+            : subscriptionValue["id"]?.ToString();
     }
 }

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -32,6 +32,143 @@ public class SubscriptionService : ISubscriptionService
     return await _unitOfWork.UserSubscriptions.HasActiveSubscriptionAsync(userId);
   }
 
+  public async Task<UserSubscription?> GetByStripeSubscriptionIdAsync(string stripeSubscriptionId)
+  {
+    return await _unitOfWork.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId);
+  }
+
+  public async Task<UserSubscription> SyncFromStripeAsync(
+      Stripe.Subscription stripeSubscription,
+      Func<Task<int?>>? resolveUserIdFallback = null)
+  {
+    if (!SubscriptionStatusMapper.TryMap(stripeSubscription.Status, out var status))
+    {
+      _logger.LogError(
+        "Unknown Stripe subscription status {Status} for subscription {SubscriptionId}; storing raw value",
+        stripeSubscription.Status, stripeSubscription.Id);
+    }
+
+    var (periodStart, periodEnd) = GetPeriodDates(stripeSubscription);
+
+    var existing = await _unitOfWork.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscription.Id);
+    if (existing != null)
+    {
+      var previousStatus = existing.Status;
+
+      existing.Status = status;
+      existing.StripeCustomerId ??= stripeSubscription.CustomerId;
+      if (periodStart.HasValue && periodEnd.HasValue)
+      {
+        existing.CurrentPeriodStart = periodStart;
+        existing.CurrentPeriodEnd = periodEnd;
+      }
+      if (status == SubscriptionStatus.Canceled && existing.CanceledAt == null)
+      {
+        existing.CanceledAt = DateTime.UtcNow;
+      }
+
+      var updated = await _unitOfWork.UserSubscriptions.UpdateAsync(existing);
+      await ApplyStatusTransitionSideEffectsAsync(existing.UserId, previousStatus, status);
+
+      _logger.LogInformation(
+        "Synced subscription {SubscriptionId} from Stripe: {PreviousStatus} -> {Status}",
+        stripeSubscription.Id, previousStatus, status);
+      return updated;
+    }
+
+    // No local row yet — either the `created` event, or a later event that arrived first.
+    var priceId = stripeSubscription.Items?.Data?.FirstOrDefault()?.Price?.Id;
+    if (string.IsNullOrEmpty(priceId))
+    {
+      throw new InvalidOperationException(
+        $"Stripe subscription {stripeSubscription.Id} has no items with a price; cannot resolve a local plan");
+    }
+
+    var plan = await GetPlanByStripePriceIdAsync(priceId)
+      ?? throw new InvalidOperationException(
+        $"No local plan matches Stripe price {priceId} for subscription {stripeSubscription.Id}; " +
+        "check SubscriptionPlans seeding against the Stripe account");
+
+    var userId = TryGetUserIdFromMetadata(stripeSubscription.Metadata);
+    if (!userId.HasValue && resolveUserIdFallback != null)
+    {
+      userId = await resolveUserIdFallback();
+    }
+    if (!userId.HasValue)
+    {
+      throw new InvalidOperationException(
+        $"Could not determine user for Stripe subscription {stripeSubscription.Id}: " +
+        "no userId in subscription or customer metadata");
+    }
+
+    // The user has paid on Stripe's side, so a conflicting local subscription is an alert,
+    // not a reason to drop the record.
+    if (await HasActiveSubscriptionAsync(userId.Value))
+    {
+      _logger.LogError(
+        "User {UserId} already has an active subscription but Stripe subscription {SubscriptionId} arrived; creating anyway",
+        userId.Value, stripeSubscription.Id);
+    }
+
+    var created = await _unitOfWork.UserSubscriptions.CreateAsync(new UserSubscription
+    {
+      UserId = userId.Value,
+      PlanId = plan.Id,
+      StripeSubscriptionId = stripeSubscription.Id,
+      StripeCustomerId = stripeSubscription.CustomerId,
+      Status = status,
+      CurrentPeriodStart = periodStart,
+      CurrentPeriodEnd = periodEnd,
+      CanceledAt = status == SubscriptionStatus.Canceled ? DateTime.UtcNow : null,
+      CreatedAt = DateTime.UtcNow,
+      UpdatedAt = DateTime.UtcNow
+    });
+
+    await ApplyStatusTransitionSideEffectsAsync(userId.Value, previousStatus: null, status);
+
+    _logger.LogInformation(
+      "Created subscription record for user {UserId} from Stripe subscription {SubscriptionId} with status {Status}",
+      userId.Value, stripeSubscription.Id, status);
+    return created;
+  }
+
+  private static (DateTime? Start, DateTime? End) GetPeriodDates(Stripe.Subscription stripeSubscription)
+  {
+    // Period dates live on subscription items (Stripe.net v49); multi-item subscriptions
+    // use the latest period end.
+    var items = stripeSubscription.Items?.Data;
+    if (items == null || items.Count == 0)
+    {
+      return (null, null);
+    }
+
+    return (items.First().CurrentPeriodStart, items.Max(i => i.CurrentPeriodEnd));
+  }
+
+  private static int? TryGetUserIdFromMetadata(IDictionary<string, string>? metadata)
+  {
+    if (metadata != null
+        && metadata.TryGetValue("userId", out var userIdStr)
+        && int.TryParse(userIdStr, out var userId))
+    {
+      return userId;
+    }
+
+    return null;
+  }
+
+  private async Task ApplyStatusTransitionSideEffectsAsync(int userId, string? previousStatus, string newStatus)
+  {
+    if (SubscriptionStatusMapper.IsEntitled(newStatus) && !SubscriptionStatusMapper.IsEntitled(previousStatus))
+    {
+      await ReactivateSyncConfigsAsync(userId);
+    }
+    else if (SubscriptionStatusMapper.IsInactive(newStatus) && !SubscriptionStatusMapper.IsInactive(previousStatus))
+    {
+      await DisableSyncConfigsForUserAsync(userId);
+    }
+  }
+
   public async Task<UserSubscription> CreateSubscriptionAsync(int userId, int planId, string stripeSubscriptionId, string stripeCustomerId)
   {
     _logger.LogInformation("Creating subscription for user {UserId} with plan {PlanId}", userId, planId);
@@ -66,16 +203,26 @@ public class SubscriptionService : ISubscriptionService
       throw new InvalidOperationException($"Subscription with Stripe ID {stripeSubscriptionId} not found");
     }
 
-    _logger.LogInformation("Updating subscription {SubscriptionId} status from {OldStatus} to {NewStatus}",
-        subscription.Id, subscription.Status, status);
+    if (!SubscriptionStatusMapper.TryMap(status, out var mappedStatus))
+    {
+      _logger.LogError(
+        "Unknown subscription status {Status} for subscription {SubscriptionId}; storing raw value",
+        status, stripeSubscriptionId);
+    }
 
-    subscription.Status = status;
-    if (status == SubscriptionStatus.Canceled)
+    _logger.LogInformation("Updating subscription {SubscriptionId} status from {OldStatus} to {NewStatus}",
+        subscription.Id, subscription.Status, mappedStatus);
+
+    var previousStatus = subscription.Status;
+    subscription.Status = mappedStatus;
+    if (mappedStatus == SubscriptionStatus.Canceled && subscription.CanceledAt == null)
     {
       subscription.CanceledAt = DateTime.UtcNow;
     }
 
-    return await _unitOfWork.UserSubscriptions.UpdateAsync(subscription);
+    var updated = await _unitOfWork.UserSubscriptions.UpdateAsync(subscription);
+    await ApplyStatusTransitionSideEffectsAsync(subscription.UserId, previousStatus, mappedStatus);
+    return updated;
   }
 
   public async Task<UserSubscription> UpdateSubscriptionDatesAsync(string stripeSubscriptionId, DateTime currentPeriodStart, DateTime currentPeriodEnd)

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -110,7 +110,7 @@ public class SubscriptionService : ISubscriptionService
         userId.Value, stripeSubscription.Id);
     }
 
-    var created = await _unitOfWork.UserSubscriptions.CreateAsync(new UserSubscription
+    var created = await _unitOfWork.UserSubscriptions.TryCreateAsync(new UserSubscription
     {
       UserId = userId.Value,
       PlanId = plan.Id,
@@ -123,6 +123,17 @@ public class SubscriptionService : ISubscriptionService
       CreatedAt = DateTime.UtcNow,
       UpdatedAt = DateTime.UtcNow
     });
+
+    if (created == null)
+    {
+      // Lost the create race: the webhook, the checkout/complete endpoint, and the
+      // reconciliation sweep can all try to materialize a brand-new subscription within
+      // seconds of payment. The unique index arbitrates; rerun to take the update path.
+      _logger.LogInformation(
+        "Concurrent writer created the row for Stripe subscription {SubscriptionId} first; syncing instead",
+        stripeSubscription.Id);
+      return await SyncFromStripeAsync(stripeSubscription, resolveUserIdFallback);
+    }
 
     await ApplyStatusTransitionSideEffectsAsync(userId.Value, previousStatus: null, status);
 

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -53,27 +53,7 @@ public class SubscriptionService : ISubscriptionService
     var existing = await _unitOfWork.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscription.Id);
     if (existing != null)
     {
-      var previousStatus = existing.Status;
-
-      existing.Status = status;
-      existing.StripeCustomerId ??= stripeSubscription.CustomerId;
-      if (periodStart.HasValue && periodEnd.HasValue)
-      {
-        existing.CurrentPeriodStart = periodStart;
-        existing.CurrentPeriodEnd = periodEnd;
-      }
-      if (status == SubscriptionStatus.Canceled && existing.CanceledAt == null)
-      {
-        existing.CanceledAt = DateTime.UtcNow;
-      }
-
-      var updated = await _unitOfWork.UserSubscriptions.UpdateAsync(existing);
-      await ApplyStatusTransitionSideEffectsAsync(existing.UserId, previousStatus, status);
-
-      _logger.LogInformation(
-        "Synced subscription {SubscriptionId} from Stripe: {PreviousStatus} -> {Status}",
-        stripeSubscription.Id, previousStatus, status);
-      return updated;
+      return await UpdateExistingFromStripeAsync(existing, stripeSubscription, status, periodStart, periodEnd);
     }
 
     // No local row yet — either the `created` event, or a later event that arrived first.
@@ -128,11 +108,20 @@ public class SubscriptionService : ISubscriptionService
     {
       // Lost the create race: the webhook, the checkout/complete endpoint, and the
       // reconciliation sweep can all try to materialize a brand-new subscription within
-      // seconds of payment. The unique index arbitrates; rerun to take the update path.
+      // seconds of payment. The unique index arbitrates; the winner's committed row must be
+      // readable now, so take the update path against it directly (bounded — no re-entry
+      // into the create path, which could loop if the violation ever came from another
+      // constraint).
       _logger.LogInformation(
         "Concurrent writer created the row for Stripe subscription {SubscriptionId} first; syncing instead",
         stripeSubscription.Id);
-      return await SyncFromStripeAsync(stripeSubscription, resolveUserIdFallback);
+
+      var winner = await _unitOfWork.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscription.Id)
+        ?? throw new InvalidOperationException(
+          $"Insert for Stripe subscription {stripeSubscription.Id} hit a unique violation, " +
+          "but no row with that StripeSubscriptionId exists — the violation came from a different constraint");
+
+      return await UpdateExistingFromStripeAsync(winner, stripeSubscription, status, periodStart, periodEnd);
     }
 
     await ApplyStatusTransitionSideEffectsAsync(userId.Value, previousStatus: null, status);
@@ -141,6 +130,36 @@ public class SubscriptionService : ISubscriptionService
       "Created subscription record for user {UserId} from Stripe subscription {SubscriptionId} with status {Status}",
       userId.Value, stripeSubscription.Id, status);
     return created;
+  }
+
+  private async Task<UserSubscription> UpdateExistingFromStripeAsync(
+      UserSubscription existing,
+      Stripe.Subscription stripeSubscription,
+      string status,
+      DateTime? periodStart,
+      DateTime? periodEnd)
+  {
+    var previousStatus = existing.Status;
+
+    existing.Status = status;
+    existing.StripeCustomerId ??= stripeSubscription.CustomerId;
+    if (periodStart.HasValue && periodEnd.HasValue)
+    {
+      existing.CurrentPeriodStart = periodStart;
+      existing.CurrentPeriodEnd = periodEnd;
+    }
+    if (status == SubscriptionStatus.Canceled && existing.CanceledAt == null)
+    {
+      existing.CanceledAt = DateTime.UtcNow;
+    }
+
+    var updated = await _unitOfWork.UserSubscriptions.UpdateAsync(existing);
+    await ApplyStatusTransitionSideEffectsAsync(existing.UserId, previousStatus, status);
+
+    _logger.LogInformation(
+      "Synced subscription {SubscriptionId} from Stripe: {PreviousStatus} -> {Status}",
+      stripeSubscription.Id, previousStatus, status);
+    return updated;
   }
 
   private static (DateTime? Start, DateTime? End) GetPeriodDates(Stripe.Subscription stripeSubscription)

--- a/api/Services/Implementations/WebhookRetryService.cs
+++ b/api/Services/Implementations/WebhookRetryService.cs
@@ -22,6 +22,9 @@ public class WebhookRetryService : IWebhookRetryService
   private const int BaseDelayMinutes = 1;
   private const int MaxDelayMinutes = 60;
   private const double JitterFactor = 0.1;
+  // A retry stuck in Processing longer than this (crash between the status write and the
+  // outcome write) is picked up again by GetPendingRetriesAsync.
+  private static readonly TimeSpan StaleProcessingThreshold = TimeSpan.FromMinutes(15);
 
   public WebhookRetryService(
     RadioWashDbContext dbContext,
@@ -101,10 +104,13 @@ public class WebhookRetryService : IWebhookRetryService
     try
     {
       var currentTime = _dateTimeProvider.UtcNow;
-      
+      var staleCutoff = currentTime - StaleProcessingThreshold;
+
       return await _dbContext.WebhookRetries
-        .Where(wr => wr.Status == WebhookRetryStatus.Pending && 
-                     wr.NextRetryAt <= currentTime &&
+        .Where(wr => (wr.Status == WebhookRetryStatus.Pending &&
+                      wr.NextRetryAt <= currentTime
+                      || wr.Status == WebhookRetryStatus.Processing &&
+                      wr.UpdatedAt <= staleCutoff) &&
                      wr.AttemptNumber <= wr.MaxRetries)
         .OrderBy(wr => wr.NextRetryAt)
         .Take(50) // Process in batches to avoid overwhelming system
@@ -136,7 +142,7 @@ public class WebhookRetryService : IWebhookRetryService
       _logger.LogInformation(
         "Webhook retry for event {EventId} superseded: event already processed or claimed by another handler",
         retry.EventId);
-      await MarkRetrySucceededAsync(retry.Id);
+      await MarkRetrySupersededAsync(retry.Id);
       return;
     }
 
@@ -158,11 +164,38 @@ public class WebhookRetryService : IWebhookRetryService
       _logger.LogWarning(ex, "Webhook retry failed for event {EventId}, attempt {AttemptNumber}: {ErrorMessage}",
         retry.EventId, retry.AttemptNumber, ex.Message);
 
-      await _idempotencyService.MarkEventFailedAsync(retry.EventId, ex.Message);
+      // The two outcome writes are independent: a failure releasing the event claim must
+      // not leave this retry row wedged in Processing (nothing else would resurrect it
+      // before the stale sweep).
+      try
+      {
+        await _idempotencyService.MarkEventFailedAsync(retry.EventId, ex.Message);
+      }
+      catch (Exception markEx)
+      {
+        _logger.LogError(markEx, "Failed to release idempotency claim for event {EventId} after retry failure",
+          retry.EventId);
+      }
 
       // Mark as failed and potentially schedule next retry
       await MarkRetryFailedAsync(retry.Id, ex.Message);
     }
+  }
+
+  private async Task MarkRetrySupersededAsync(int retryId)
+  {
+    var retry = await _dbContext.WebhookRetries.FindAsync(retryId);
+    if (retry == null)
+    {
+      _logger.LogWarning("Webhook retry with ID {RetryId} not found when marking as superseded", retryId);
+      return;
+    }
+
+    retry.Status = WebhookRetryStatus.Superseded;
+    retry.UpdatedAt = _dateTimeProvider.UtcNow;
+
+    _dbContext.WebhookRetries.Update(retry);
+    await _dbContext.SaveChangesAsync();
   }
 
   public async Task MarkRetrySucceededAsync(int retryId)

--- a/api/Services/Implementations/WebhookRetryService.cs
+++ b/api/Services/Implementations/WebhookRetryService.cs
@@ -56,13 +56,25 @@ public class WebhookRetryService : IWebhookRetryService
 
       if (existingRetry != null)
       {
-        // Update existing retry with new attempt
-        existingRetry.AttemptNumber = attemptNumber;
+        if (existingRetry.Status == WebhookRetryStatus.MaxRetriesExceeded)
+        {
+          // The internal loop already gave up on this event; Stripe's own redelivery (we
+          // return 500 on failure) is the remaining recovery path. Re-arming here would let
+          // every failing redelivery bypass the MaxRetries bound.
+          _logger.LogInformation(
+            "Not re-arming webhook retry for event {EventId}: internal retries exhausted, deferring to Stripe redelivery",
+            eventId);
+          return;
+        }
+
+        // Re-arm the retry, but never lower the attempt counter: a failing live redelivery
+        // must not reset the internal loop's escalation and backoff progress.
+        existingRetry.AttemptNumber = Math.Max(existingRetry.AttemptNumber, attemptNumber);
         existingRetry.LastErrorMessage = errorMessage;
-        existingRetry.NextRetryAt = CalculateNextRetryTime(attemptNumber);
+        existingRetry.NextRetryAt = CalculateNextRetryTime(existingRetry.AttemptNumber);
         existingRetry.Status = WebhookRetryStatus.Pending;
         existingRetry.UpdatedAt = _dateTimeProvider.UtcNow;
-        
+
         _dbContext.WebhookRetries.Update(existingRetry);
       }
       else

--- a/api/Services/Implementations/WebhookRetryService.cs
+++ b/api/Services/Implementations/WebhookRetryService.cs
@@ -11,10 +11,12 @@ public class WebhookRetryService : IWebhookRetryService
   private readonly RadioWashDbContext _dbContext;
   private readonly ILogger<WebhookRetryService> _logger;
   private readonly IWebhookProcessor _webhookProcessor;
+  private readonly IEventUtility _eventUtility;
+  private readonly IIdempotencyService _idempotencyService;
   private readonly IDateTimeProvider _dateTimeProvider;
   private readonly IRandomProvider _randomProvider;
   private readonly IErrorClassifier _errorClassifier;
-  
+
   // Configuration constants
   private const int DefaultMaxRetries = 5;
   private const int BaseDelayMinutes = 1;
@@ -25,6 +27,8 @@ public class WebhookRetryService : IWebhookRetryService
     RadioWashDbContext dbContext,
     ILogger<WebhookRetryService> logger,
     IWebhookProcessor webhookProcessor,
+    IEventUtility eventUtility,
+    IIdempotencyService idempotencyService,
     IDateTimeProvider dateTimeProvider,
     IRandomProvider randomProvider,
     IErrorClassifier errorClassifier)
@@ -32,6 +36,8 @@ public class WebhookRetryService : IWebhookRetryService
     _dbContext = dbContext;
     _logger = logger;
     _webhookProcessor = webhookProcessor;
+    _eventUtility = eventUtility;
+    _idempotencyService = idempotencyService;
     _dateTimeProvider = dateTimeProvider;
     _randomProvider = randomProvider;
     _errorClassifier = errorClassifier;
@@ -113,28 +119,47 @@ public class WebhookRetryService : IWebhookRetryService
 
   public async Task ProcessRetryAsync(WebhookRetry retry)
   {
+    // Mark as processing to prevent concurrent processing
+    retry.Status = WebhookRetryStatus.Processing;
+    retry.UpdatedAt = _dateTimeProvider.UtcNow;
+    _dbContext.WebhookRetries.Update(retry);
+    await _dbContext.SaveChangesAsync();
+
+    // The idempotency claim gates this path too: a Stripe redelivery (we return 500 on
+    // failure, so Stripe keeps redelivering) may be processing the same event right now.
+    var claimed = await _idempotencyService.TryProcessEventAsync(retry.EventId, retry.EventType);
+    if (!claimed)
+    {
+      // Another handler owns the event or it already succeeded. If that handler fails,
+      // it schedules its own retry (updating this row back to Pending), so this attempt
+      // can be closed out as superseded.
+      _logger.LogInformation(
+        "Webhook retry for event {EventId} superseded: event already processed or claimed by another handler",
+        retry.EventId);
+      await MarkRetrySucceededAsync(retry.Id);
+      return;
+    }
+
     try
     {
-      // Mark as processing to prevent concurrent processing
-      retry.Status = WebhookRetryStatus.Processing;
-      retry.UpdatedAt = _dateTimeProvider.UtcNow;
-      _dbContext.WebhookRetries.Update(retry);
-      await _dbContext.SaveChangesAsync();
-
-      _logger.LogInformation("Processing webhook retry for event {EventId}, attempt {AttemptNumber}", 
+      _logger.LogInformation("Processing webhook retry for event {EventId}, attempt {AttemptNumber}",
         retry.EventId, retry.AttemptNumber);
 
-      // Process the webhook
-      await _webhookProcessor.ProcessWebhookAsync(retry.Payload, retry.Signature);
-      
-      // Mark as succeeded
+      // The stored payload was signature-verified when first received; Stripe's timestamp
+      // tolerance (5 min) makes re-verification impossible here by design, so parse only.
+      var stripeEvent = _eventUtility.ParseEvent(retry.Payload);
+      await _webhookProcessor.ProcessEventAsync(stripeEvent);
+
+      await _idempotencyService.MarkEventSuccessfulAsync(retry.EventId);
       await MarkRetrySucceededAsync(retry.Id);
     }
     catch (Exception ex)
     {
-      _logger.LogWarning(ex, "Webhook retry failed for event {EventId}, attempt {AttemptNumber}: {ErrorMessage}", 
+      _logger.LogWarning(ex, "Webhook retry failed for event {EventId}, attempt {AttemptNumber}: {ErrorMessage}",
         retry.EventId, retry.AttemptNumber, ex.Message);
-      
+
+      await _idempotencyService.MarkEventFailedAsync(retry.EventId, ex.Message);
+
       // Mark as failed and potentially schedule next retry
       await MarkRetryFailedAsync(retry.Id, ex.Message);
     }

--- a/api/Services/Interfaces/IEventUtility.cs
+++ b/api/Services/Interfaces/IEventUtility.cs
@@ -5,4 +5,12 @@ namespace RadioWash.Api.Services.Interfaces;
 public interface IEventUtility
 {
   Event ConstructEvent(string payload, string signature, string secret);
+
+  /// <summary>
+  /// Deserializes a webhook payload WITHOUT signature verification. Only for payloads that
+  /// were already verified when first received (the internal retry queue): Stripe's
+  /// signature timestamp tolerance (5 minutes) makes re-verification of a stored payload
+  /// impossible by design.
+  /// </summary>
+  Event ParseEvent(string payload);
 }

--- a/api/Services/Interfaces/ISubscriptionService.cs
+++ b/api/Services/Interfaces/ISubscriptionService.cs
@@ -6,8 +6,18 @@ public interface ISubscriptionService
 {
   Task<UserSubscription?> GetActiveSubscriptionAsync(int userId);
   Task<bool> HasActiveSubscriptionAsync(int userId);
+  Task<UserSubscription?> GetByStripeSubscriptionIdAsync(string stripeSubscriptionId);
   Task<UserSubscription> CreateSubscriptionAsync(int userId, int planId, string stripeSubscriptionId, string stripeCustomerId);
   Task<UserSubscription> UpdateSubscriptionStatusAsync(string stripeSubscriptionId, string status);
+  // Creates or updates the local subscription row from Stripe's current view of the
+  // subscription — the single write path for webhook events, checkout reconciliation, and
+  // the reconciliation job. Keyed on StripeSubscriptionId, so event ordering doesn't
+  // matter: an `updated` arriving before `created` simply creates the row. Status goes
+  // through SubscriptionStatusMapper and transition side effects (disabling or
+  // re-enabling sync configs) are applied here. resolveUserIdFallback is invoked only
+  // when a row must be created and the subscription's metadata carries no userId
+  // (e.g. a Stripe API lookup of the customer's metadata).
+  Task<UserSubscription> SyncFromStripeAsync(Stripe.Subscription stripeSubscription, Func<Task<int?>>? resolveUserIdFallback = null);
   Task<UserSubscription> UpdateSubscriptionDatesAsync(string stripeSubscriptionId, DateTime currentPeriodStart, DateTime currentPeriodEnd);
   Task<UserSubscription> CancelSubscriptionAsync(int userId);
   Task<IEnumerable<SubscriptionPlan>> GetAvailablePlansAsync();

--- a/api/Services/Interfaces/IWebhookProcessor.cs
+++ b/api/Services/Interfaces/IWebhookProcessor.cs
@@ -1,12 +1,14 @@
+using Stripe;
+
 namespace RadioWash.Api.Services.Interfaces;
 
 /// <summary>
-/// Processes webhook events without retry logic to avoid circular dependencies
+/// Dispatches pre-verified Stripe webhook events to their handlers. Signature verification,
+/// idempotency claiming, and retry scheduling live in the caller (StripePaymentService for
+/// live deliveries, WebhookRetryService for replays) — this processor assumes the event is
+/// authentic and throws on any processing failure so callers can record and retry it.
 /// </summary>
 public interface IWebhookProcessor
 {
-  /// <summary>
-  /// Processes a webhook event payload
-  /// </summary>
-  Task ProcessWebhookAsync(string payload, string signature);
+  Task ProcessEventAsync(Event stripeEvent);
 }


### PR DESCRIPTION
PR 1 of 4 in the payment production-readiness stack (merge order: this → billing-lifecycle → stripe-reconciliation → payment-frontend; retarget children before squash-merging).

## Problem
A transient failure during webhook processing permanently lost the event: the controller returned 400 (Stripe stops redelivering), the idempotency row blocked redelivery of failed events, and the internal retry queue re-verified signatures whose 5-minute timestamp tolerance had long expired. A lost `customer.subscription.created` = charged user, no subscription, no recovery.

## Changes
- Controller: 400 only for signature failures, 500 for processing failures (Stripe redelivers up to 3 days)
- `ProcessedWebhookEvents` rows are claims (Processing/Succeeded/Failed + attempt tracking); failed events are re-claimable, stale claims are taken over via a compare-and-swap on Status+LastAttemptAt concurrency tokens
- `IWebhookProcessor` takes a pre-verified event; retries replay the stored (already-authenticated) payload without signature re-verification, under the same idempotency claim
- `SyncFromStripeAsync` upserts keyed on Stripe subscription id: out-of-order events create the row instead of poisoning the claim; all subscription-affecting events fetch and sync the subscription's current Stripe state rather than applying event snapshots (a delayed redelivery can't resurrect a canceled sub); creation races between webhook/reconcile/sweep fall back to updating the winner's row
- Status transitions centralized: Stripe-side cancellations now disable sync configs; trialing counts as entitled; `incomplete_expired` maps to canceled
- Silent LogError-and-return paths now throw (recorded, alertable, recoverable)
- Delivery is **at-least-once** by design; handlers are idempotent

## Testing
606 unit tests green on this branch, including DB-level CAS races (two contexts), retry replay of a >300s-old payload, out-of-order upsert, and unmocked `EventUtility.ConstructEvent` verification (valid/tampered/stale signatures). Adversarial code review completed; all must-fix findings addressed in the second commit.
