### PR TITLE
feat(api): fix cancellation to go through Stripe and harden checkout

### DIFF
--- a/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
+++ b/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using RadioWash.Api.Controllers;
@@ -33,15 +34,8 @@ public class SubscriptionControllerTests : IDisposable
     _mockPaymentService = new Mock<IPaymentService>();
     _mockLogger = new Mock<ILogger<SubscriptionController>>();
 
-    _controller = new SubscriptionController(
-        _context,
-        _mockSubscriptionService.Object,
-        _mockPaymentService.Object,
-        _mockLogger.Object
-    );
-
-    // Setup authenticated user context
-    SetupAuthenticatedUser();
+    SeedAuthenticatedUser();
+    _controller = CreateController(checkoutEnabled: true);
   }
 
   public void Dispose()
@@ -49,7 +43,7 @@ public class SubscriptionControllerTests : IDisposable
     _context.Dispose();
   }
 
-  private void SetupAuthenticatedUser()
+  private void SeedAuthenticatedUser()
   {
     var user = new User
     {
@@ -61,6 +55,24 @@ public class SubscriptionControllerTests : IDisposable
     };
     _context.Users.Add(user);
     _context.SaveChanges();
+  }
+
+  private SubscriptionController CreateController(bool checkoutEnabled)
+  {
+    var configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+          ["Features:CheckoutEnabled"] = checkoutEnabled.ToString().ToLowerInvariant()
+        })
+        .Build();
+
+    var controller = new SubscriptionController(
+        _context,
+        _mockSubscriptionService.Object,
+        _mockPaymentService.Object,
+        configuration,
+        _mockLogger.Object
+    );
 
     var claims = new List<Claim>
         {
@@ -69,10 +81,17 @@ public class SubscriptionControllerTests : IDisposable
     var identity = new ClaimsIdentity(claims, "TestAuth");
     var principal = new ClaimsPrincipal(identity);
 
-    _controller.ControllerContext = new ControllerContext()
+    controller.ControllerContext = new ControllerContext()
     {
       HttpContext = new DefaultHttpContext() { User = principal }
     };
+
+    return controller;
+  }
+
+  private static object? GetProperty(object response, string name)
+  {
+    return response.GetType().GetProperty(name)?.GetValue(response);
   }
 
   [Fact]
@@ -111,6 +130,25 @@ public class SubscriptionControllerTests : IDisposable
     var okResult = Assert.IsType<OkObjectResult>(result.Result);
     var returnedSubscription = Assert.IsType<UserSubscriptionDto>(okResult.Value);
     Assert.Equal(SubscriptionStatus.Active, returnedSubscription.Status);
+    Assert.False(returnedSubscription.CancelAtPeriodEnd);
+  }
+
+  [Fact]
+  public async Task GetCurrentSubscription_WithCancellationScheduled_ShouldExposeCancelAtPeriodEnd()
+  {
+    // Arrange
+    var subscription = CreateUserSubscriptionWithPlan(1);
+    subscription.CancelAtPeriodEnd = true;
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
+
+    // Act
+    var result = await _controller.GetCurrentSubscription();
+
+    // Assert
+    var okResult = Assert.IsType<OkObjectResult>(result.Result);
+    var returnedSubscription = Assert.IsType<UserSubscriptionDto>(okResult.Value);
+    Assert.True(returnedSubscription.CancelAtPeriodEnd);
   }
 
   [Fact]
@@ -128,52 +166,293 @@ public class SubscriptionControllerTests : IDisposable
     Assert.Null(okResult.Value);
   }
 
+  #region CreateCheckoutSession
+
   [Fact]
-  public async Task CreateCheckoutSession_WithValidRequest_ShouldReturnOkWithCheckoutUrl()
+  public async Task CreateCheckoutSession_WithCheckoutDisabled_ShouldReturnServiceUnavailable()
+  {
+    // Arrange - the kill switch short-circuits before any service call
+    var controller = CreateController(checkoutEnabled: false);
+
+    // Act
+    var result = await controller.CreateCheckoutSession(new CreateCheckoutDto());
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status503ServiceUnavailable, problem.Status);
+    _mockPaymentService.Verify(
+        x => x.CreateCheckoutSessionAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>()),
+        Times.Never);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSession_WithActiveSubscription_ShouldReturnConflict()
   {
     // Arrange
-    var request = new CreateCheckoutDto
-    {
-      PlanPriceId = "price_test123"
-    };
+    _mockSubscriptionService.Setup(x => x.HasActiveSubscriptionAsync(1))
+        .ReturnsAsync(true);
+
+    // Act
+    var result = await _controller.CreateCheckoutSession(new CreateCheckoutDto());
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status409Conflict, problem.Status);
+    _mockPaymentService.Verify(
+        x => x.CreateCheckoutSessionAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>()),
+        Times.Never);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSession_WithNullPlanId_ShouldUseFirstAvailablePlan()
+  {
+    // Arrange
+    var plan = CreateSubscriptionPlan(1, "Basic", stripePriceId: "price_default");
     var checkoutUrl = "https://checkout.stripe.com/test";
 
-    _mockPaymentService.Setup(x => x.CreateCheckoutSessionAsync(1, request.PlanPriceId))
+    _mockSubscriptionService.Setup(x => x.GetAvailablePlansAsync())
+        .ReturnsAsync(new[] { plan });
+    _mockPaymentService.Setup(x => x.CreateCheckoutSessionAsync(1, "price_default", "req-1"))
         .ReturnsAsync(checkoutUrl);
 
     // Act
-    var result = await _controller.CreateCheckoutSession(request);
+    var result = await _controller.CreateCheckoutSession(
+        new CreateCheckoutDto { PlanId = null, ClientRequestId = "req-1" });
 
     // Assert
     var okResult = Assert.IsType<OkObjectResult>(result);
-    var response = okResult.Value;
-    Assert.NotNull(response);
-    var checkoutUrlProperty = response.GetType().GetProperty("checkoutUrl");
-    Assert.Equal(checkoutUrl, checkoutUrlProperty?.GetValue(response));
+    Assert.NotNull(okResult.Value);
+    Assert.Equal(checkoutUrl, GetProperty(okResult.Value!, "checkoutUrl"));
+    _mockPaymentService.Verify(x => x.CreateCheckoutSessionAsync(1, "price_default", "req-1"), Times.Once);
+    _mockSubscriptionService.Verify(x => x.GetPlanByIdAsync(It.IsAny<int>()), Times.Never);
   }
 
   [Fact]
-  public async Task CreateCheckoutSession_WhenPaymentServiceThrows_ShouldReturnBadRequest()
+  public async Task CreateCheckoutSession_WithExplicitPlanId_ShouldResolvePlanById()
   {
     // Arrange
-    var request = new CreateCheckoutDto
-    {
-      PlanPriceId = "invalid_price_id"
-    };
+    var plan = CreateSubscriptionPlan(2, "Premium", stripePriceId: "price_premium");
+    var checkoutUrl = "https://checkout.stripe.com/test";
 
-    _mockPaymentService.Setup(x => x.CreateCheckoutSessionAsync(1, request.PlanPriceId))
-        .ThrowsAsync(new Exception("Invalid price ID"));
+    _mockSubscriptionService.Setup(x => x.GetPlanByIdAsync(2))
+        .ReturnsAsync(plan);
+    _mockPaymentService.Setup(x => x.CreateCheckoutSessionAsync(1, "price_premium", null))
+        .ReturnsAsync(checkoutUrl);
 
     // Act
-    var result = await _controller.CreateCheckoutSession(request);
+    var result = await _controller.CreateCheckoutSession(new CreateCheckoutDto { PlanId = 2 });
 
     // Assert
-    var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
-    var response = badRequestResult.Value;
-    Assert.NotNull(response);
-    var errorProperty = response.GetType().GetProperty("error");
-    Assert.Equal("Failed to create checkout session", errorProperty?.GetValue(response));
+    var okResult = Assert.IsType<OkObjectResult>(result);
+    Assert.Equal(checkoutUrl, GetProperty(okResult.Value!, "checkoutUrl"));
+    _mockSubscriptionService.Verify(x => x.GetAvailablePlansAsync(), Times.Never);
   }
+
+  [Fact]
+  public async Task CreateCheckoutSession_WithUnknownPlanId_ShouldReturnBadRequest()
+  {
+    // Arrange
+    _mockSubscriptionService.Setup(x => x.GetPlanByIdAsync(99))
+        .ReturnsAsync((SubscriptionPlan?)null);
+
+    // Act
+    var result = await _controller.CreateCheckoutSession(new CreateCheckoutDto { PlanId = 99 });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status400BadRequest, problem.Status);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSession_WithInactivePlan_ShouldReturnBadRequest()
+  {
+    // Arrange
+    var plan = CreateSubscriptionPlan(2, "Retired", stripePriceId: "price_retired");
+    plan.IsActive = false;
+    _mockSubscriptionService.Setup(x => x.GetPlanByIdAsync(2))
+        .ReturnsAsync(plan);
+
+    // Act
+    var result = await _controller.CreateCheckoutSession(new CreateCheckoutDto { PlanId = 2 });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status400BadRequest, problem.Status);
+    _mockPaymentService.Verify(
+        x => x.CreateCheckoutSessionAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>()),
+        Times.Never);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSession_WithPlanMissingStripePrice_ShouldReturnBadRequest()
+  {
+    // Arrange
+    var plan = CreateSubscriptionPlan(2, "Unpriced", stripePriceId: null);
+    _mockSubscriptionService.Setup(x => x.GetPlanByIdAsync(2))
+        .ReturnsAsync(plan);
+
+    // Act
+    var result = await _controller.CreateCheckoutSession(new CreateCheckoutDto { PlanId = 2 });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status400BadRequest, problem.Status);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSession_WhenPaymentServiceThrows_ShouldReturnInternalServerError()
+  {
+    // Arrange
+    var plan = CreateSubscriptionPlan(1, "Basic", stripePriceId: "price_default");
+    _mockSubscriptionService.Setup(x => x.GetAvailablePlansAsync())
+        .ReturnsAsync(new[] { plan });
+    _mockPaymentService.Setup(x => x.CreateCheckoutSessionAsync(1, "price_default", null))
+        .ThrowsAsync(new Exception("Stripe unavailable"));
+
+    // Act
+    var result = await _controller.CreateCheckoutSession(new CreateCheckoutDto());
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status500InternalServerError, problem.Status);
+  }
+
+  #endregion
+
+  #region CompleteCheckout
+
+  [Fact]
+  public async Task CompleteCheckout_WithEmptySessionId_ShouldReturnBadRequest()
+  {
+    // Act
+    var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "" });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status400BadRequest, problem.Status);
+    _mockPaymentService.Verify(x => x.GetCheckoutSessionAsync(It.IsAny<string>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task CompleteCheckout_WhenSessionNotFoundOnStripe_ShouldReturnNotFound()
+  {
+    // Arrange
+    _mockPaymentService.Setup(x => x.GetCheckoutSessionAsync("cs_missing"))
+        .ThrowsAsync(new Stripe.StripeException("No such checkout session"));
+
+    // Act
+    var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "cs_missing" });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status404NotFound, problem.Status);
+  }
+
+  [Fact]
+  public async Task CompleteCheckout_WithMissingUserMetadata_ShouldReturnForbidden()
+  {
+    // Arrange - a session without a userId claim can't be attributed to the caller
+    _mockPaymentService.Setup(x => x.GetCheckoutSessionAsync("cs_1"))
+        .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_1" });
+
+    // Act
+    var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "cs_1" });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status403Forbidden, problem.Status);
+    _mockSubscriptionService.Verify(
+        x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()),
+        Times.Never);
+  }
+
+  [Fact]
+  public async Task CompleteCheckout_WithAnotherUsersSession_ShouldReturnForbidden()
+  {
+    // Arrange
+    _mockPaymentService.Setup(x => x.GetCheckoutSessionAsync("cs_1"))
+        .ReturnsAsync(new Stripe.Checkout.Session
+        {
+          Id = "cs_1",
+          Metadata = new Dictionary<string, string> { { "userId", "999" } }
+        });
+
+    // Act
+    var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "cs_1" });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status403Forbidden, problem.Status);
+    _mockSubscriptionService.Verify(
+        x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()),
+        Times.Never);
+  }
+
+  [Fact]
+  public async Task CompleteCheckout_WithSubscription_ShouldSyncAndReturnStatus()
+  {
+    // Arrange
+    var stripeSubscription = new Stripe.Subscription { Id = "sub_1" };
+    _mockPaymentService.Setup(x => x.GetCheckoutSessionAsync("cs_1"))
+        .ReturnsAsync(new Stripe.Checkout.Session
+        {
+          Id = "cs_1",
+          Metadata = new Dictionary<string, string> { { "userId", "1" } },
+          Subscription = stripeSubscription
+        });
+    _mockSubscriptionService.Setup(x => x.HasActiveSubscriptionAsync(1))
+        .ReturnsAsync(true);
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(CreateUserSubscriptionWithPlan(1));
+
+    // Act
+    var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "cs_1" });
+
+    // Assert
+    var okResult = Assert.IsType<OkObjectResult>(result);
+    Assert.NotNull(okResult.Value);
+    Assert.True((bool)GetProperty(okResult.Value!, "hasActiveSubscription")!);
+    Assert.Equal("Basic", GetProperty(okResult.Value!, "planName"));
+    _mockSubscriptionService.Verify(
+        x => x.SyncFromStripeAsync(stripeSubscription, It.IsAny<Func<Task<int?>>?>()),
+        Times.Once);
+  }
+
+  [Fact]
+  public async Task CompleteCheckout_WithoutSubscriptionOnSession_ShouldNotSyncButStillReturnOk()
+  {
+    // Arrange - payment may still be processing; the webhook will finish the job
+    _mockPaymentService.Setup(x => x.GetCheckoutSessionAsync("cs_1"))
+        .ReturnsAsync(new Stripe.Checkout.Session
+        {
+          Id = "cs_1",
+          Metadata = new Dictionary<string, string> { { "userId", "1" } },
+          Subscription = null
+        });
+
+    // Act
+    var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "cs_1" });
+
+    // Assert
+    var okResult = Assert.IsType<OkObjectResult>(result);
+    Assert.NotNull(okResult.Value);
+    Assert.False((bool)GetProperty(okResult.Value!, "hasActiveSubscription")!);
+    _mockSubscriptionService.Verify(
+        x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()),
+        Times.Never);
+  }
+
+  #endregion
 
   [Fact]
   public async Task CreatePortalSession_WithActiveSubscription_ShouldReturnOkWithPortalUrl()
@@ -195,46 +474,137 @@ public class SubscriptionControllerTests : IDisposable
     var okResult = Assert.IsType<OkObjectResult>(result);
     var response = okResult.Value;
     Assert.NotNull(response);
-    var portalUrlProperty = response.GetType().GetProperty("portalUrl");
-    Assert.Equal(portalUrl, portalUrlProperty?.GetValue(response));
+    Assert.Equal(portalUrl, GetProperty(response!, "portalUrl"));
+  }
+
+  #region CancelSubscription
+
+  [Fact]
+  public async Task CancelSubscription_WithNoSubscription_ShouldReturnNotFound()
+  {
+    // Arrange
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync((UserSubscription?)null);
+
+    // Act
+    var result = await _controller.CancelSubscription();
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status404NotFound, problem.Status);
+    _mockPaymentService.Verify(x => x.CancelAtPeriodEndAsync(It.IsAny<string>()), Times.Never);
   }
 
   [Fact]
-  public async Task CancelSubscription_WithValidUserId_ShouldReturnOk()
+  public async Task CancelSubscription_WithNonEntitledStatus_ShouldReturnNotFound()
+  {
+    // Arrange - a canceled/past_due subscription has nothing left to cancel
+    var subscription = CreateUserSubscription(1, SubscriptionStatus.Canceled);
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
+
+    // Act
+    var result = await _controller.CancelSubscription();
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status404NotFound, problem.Status);
+    _mockPaymentService.Verify(x => x.CancelAtPeriodEndAsync(It.IsAny<string>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task CancelSubscription_WithMissingStripeSubscriptionId_ShouldReturnNotFound()
   {
     // Arrange
-    var canceledSubscription = CreateUserSubscription(1, SubscriptionStatus.Canceled);
-    _mockSubscriptionService.Setup(x => x.CancelSubscriptionAsync(1))
-        .ReturnsAsync(canceledSubscription);
+    var subscription = CreateUserSubscription(1);
+    subscription.StripeSubscriptionId = null;
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
+
+    // Act
+    var result = await _controller.CancelSubscription();
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status404NotFound, problem.Status);
+  }
+
+  [Fact]
+  public async Task CancelSubscription_WhenAlreadyScheduled_ShouldReturnOkWithoutCallingStripe()
+  {
+    // Arrange - idempotent success, no second Stripe round-trip
+    var subscription = CreateUserSubscription(1);
+    subscription.CancelAtPeriodEnd = true;
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
 
     // Act
     var result = await _controller.CancelSubscription();
 
     // Assert
     var okResult = Assert.IsType<OkObjectResult>(result);
-    var response = okResult.Value;
-    Assert.NotNull(response);
-    var messageProperty = response.GetType().GetProperty("message");
-    Assert.Equal("Subscription canceled successfully", messageProperty?.GetValue(response));
+    Assert.NotNull(okResult.Value);
+    Assert.True((bool)GetProperty(okResult.Value!, "cancelAtPeriodEnd")!);
+    Assert.Equal(subscription.CurrentPeriodEnd, GetProperty(okResult.Value!, "activeUntil"));
+    _mockPaymentService.Verify(x => x.CancelAtPeriodEndAsync(It.IsAny<string>()), Times.Never);
+    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(It.IsAny<int>()), Times.Never);
   }
 
   [Fact]
-  public async Task CancelSubscription_WhenServiceThrows_ShouldReturnBadRequest()
+  public async Task CancelSubscription_HappyPath_ShouldCallStripeBeforePersistingLocalFlag()
   {
     // Arrange
-    _mockSubscriptionService.Setup(x => x.CancelSubscriptionAsync(1))
-        .ThrowsAsync(new Exception("Cancellation failed"));
+    var subscription = CreateUserSubscription(1);
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
+
+    var callOrder = new List<string>();
+    _mockPaymentService.Setup(x => x.CancelAtPeriodEndAsync("sub_test123"))
+        .Callback(() => callOrder.Add("stripe"))
+        .Returns(Task.CompletedTask);
+    _mockSubscriptionService.Setup(x => x.MarkCancellationRequestedAsync(1))
+        .Callback(() => callOrder.Add("local"))
+        .ReturnsAsync(subscription);
 
     // Act
     var result = await _controller.CancelSubscription();
 
     // Assert
-    var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
-    var response = badRequestResult.Value;
-    Assert.NotNull(response);
-    var errorProperty = response.GetType().GetProperty("error");
-    Assert.Equal("Failed to cancel subscription", errorProperty?.GetValue(response));
+    var okResult = Assert.IsType<OkObjectResult>(result);
+    Assert.NotNull(okResult.Value);
+    Assert.True((bool)GetProperty(okResult.Value!, "cancelAtPeriodEnd")!);
+    Assert.Equal(subscription.CurrentPeriodEnd, GetProperty(okResult.Value!, "activeUntil"));
+
+    _mockPaymentService.Verify(x => x.CancelAtPeriodEndAsync("sub_test123"), Times.Once);
+    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(1), Times.Once);
+    // Stripe must accept the cancellation before the local flag is persisted
+    Assert.Equal(new[] { "stripe", "local" }, callOrder);
   }
+
+  [Fact]
+  public async Task CancelSubscription_WhenStripeCallFails_ShouldReturn500AndNotPersistLocalFlag()
+  {
+    // Arrange
+    var subscription = CreateUserSubscription(1);
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
+    _mockPaymentService.Setup(x => x.CancelAtPeriodEndAsync("sub_test123"))
+        .ThrowsAsync(new Stripe.StripeException("Stripe API unavailable"));
+
+    // Act
+    var result = await _controller.CancelSubscription();
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status500InternalServerError, problem.Status);
+    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(It.IsAny<int>()), Times.Never);
+  }
+
+  #endregion
 
   [Fact]
   public async Task HandleStripeWebhook_WithValidPayload_ShouldReturnOk()
@@ -311,7 +681,7 @@ public class SubscriptionControllerTests : IDisposable
     Assert.Equal("Invalid Stripe signature", badRequestResult.Value);
   }
 
-  private static SubscriptionPlan CreateSubscriptionPlan(int id, string name)
+  private static SubscriptionPlan CreateSubscriptionPlan(int id, string name, string? stripePriceId = "price_test")
   {
     return new SubscriptionPlan
     {
@@ -319,6 +689,7 @@ public class SubscriptionControllerTests : IDisposable
       Name = name,
       PriceInCents = 999,
       BillingPeriod = "monthly",
+      StripePriceId = stripePriceId,
       IsActive = true,
       CreatedAt = DateTime.UtcNow,
       UpdatedAt = DateTime.UtcNow
@@ -344,20 +715,9 @@ public class SubscriptionControllerTests : IDisposable
 
   private static UserSubscription CreateUserSubscriptionWithPlan(int userId)
   {
-    return new UserSubscription
-    {
-      Id = 1,
-      UserId = userId,
-      PlanId = 1,
-      Plan = CreateSubscriptionPlan(1, "Basic"),
-      StripeSubscriptionId = "sub_test123",
-      StripeCustomerId = "cus_test123",
-      Status = SubscriptionStatus.Active,
-      CurrentPeriodStart = DateTime.UtcNow.AddDays(-30),
-      CurrentPeriodEnd = DateTime.UtcNow.AddDays(30),
-      CreatedAt = DateTime.UtcNow,
-      UpdatedAt = DateTime.UtcNow
-    };
+    var subscription = CreateUserSubscription(userId);
+    subscription.Plan = CreateSubscriptionPlan(1, "Basic");
+    return subscription;
   }
 
   [Fact]
@@ -374,16 +734,19 @@ public class SubscriptionControllerTests : IDisposable
     var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
     var response = badRequestResult.Value;
     Assert.NotNull(response);
-    var errorProperty = response.GetType().GetProperty("error");
-    Assert.Equal("No active subscription found", errorProperty?.GetValue(response));
+    Assert.Equal("No active subscription found", GetProperty(response!, "error"));
   }
 
   [Fact]
-  public async Task GetSubscriptionStatus_WithActiveSubscription_ShouldReturnOkWithTrue()
+  public async Task GetSubscriptionStatus_WithActiveSubscription_ShouldReturnFullPayload()
   {
     // Arrange
+    var subscription = CreateUserSubscriptionWithPlan(1);
+    subscription.CancelAtPeriodEnd = true;
     _mockSubscriptionService.Setup(x => x.HasActiveSubscriptionAsync(1))
         .ReturnsAsync(true);
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
 
     // Act
     var result = await _controller.GetSubscriptionStatus();
@@ -392,16 +755,22 @@ public class SubscriptionControllerTests : IDisposable
     var okResult = Assert.IsType<OkObjectResult>(result);
     var response = okResult.Value;
     Assert.NotNull(response);
-    var hasActiveSubscriptionProperty = response.GetType().GetProperty("hasActiveSubscription");
-    Assert.True((bool)hasActiveSubscriptionProperty?.GetValue(response)!);
+    Assert.True((bool)GetProperty(response!, "hasActiveSubscription")!);
+    Assert.Equal(subscription.Id, GetProperty(response!, "subscriptionId"));
+    Assert.Equal("Basic", GetProperty(response!, "planName"));
+    Assert.Equal(SubscriptionStatus.Active, GetProperty(response!, "status"));
+    Assert.Equal(subscription.CurrentPeriodEnd, GetProperty(response!, "currentPeriodEnd"));
+    Assert.True((bool)GetProperty(response!, "cancelAtPeriodEnd")!);
   }
 
   [Fact]
-  public async Task GetSubscriptionStatus_WithNoActiveSubscription_ShouldReturnOkWithFalse()
+  public async Task GetSubscriptionStatus_WithNoActiveSubscription_ShouldReturnEmptyPayload()
   {
     // Arrange
     _mockSubscriptionService.Setup(x => x.HasActiveSubscriptionAsync(1))
         .ReturnsAsync(false);
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync((UserSubscription?)null);
 
     // Act
     var result = await _controller.GetSubscriptionStatus();
@@ -410,8 +779,11 @@ public class SubscriptionControllerTests : IDisposable
     var okResult = Assert.IsType<OkObjectResult>(result);
     var response = okResult.Value;
     Assert.NotNull(response);
-    var hasActiveSubscriptionProperty = response.GetType().GetProperty("hasActiveSubscription");
-    Assert.False((bool)hasActiveSubscriptionProperty?.GetValue(response)!);
+    Assert.False((bool)GetProperty(response!, "hasActiveSubscription")!);
+    Assert.Null(GetProperty(response!, "subscriptionId"));
+    Assert.Null(GetProperty(response!, "planName"));
+    Assert.Null(GetProperty(response!, "status"));
+    Assert.False((bool)GetProperty(response!, "cancelAtPeriodEnd")!);
   }
 
   [Fact]

--- a/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
+++ b/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
@@ -208,24 +208,25 @@ public class SubscriptionControllerTests : IDisposable
   [Fact]
   public async Task CreateCheckoutSession_WithNullPlanId_ShouldUseFirstAvailablePlan()
   {
-    // Arrange
+    // Arrange - ClientRequestId must be a UUID (the frontend sends crypto.randomUUID())
+    var clientRequestId = "1c1b7f6e-9f6c-4f4e-8a58-0c8f4a1d2b3c";
     var plan = CreateSubscriptionPlan(1, "Basic", stripePriceId: "price_default");
     var checkoutUrl = "https://checkout.stripe.com/test";
 
     _mockSubscriptionService.Setup(x => x.GetAvailablePlansAsync())
         .ReturnsAsync(new[] { plan });
-    _mockPaymentService.Setup(x => x.CreateCheckoutSessionAsync(1, "price_default", "req-1"))
+    _mockPaymentService.Setup(x => x.CreateCheckoutSessionAsync(1, "price_default", clientRequestId))
         .ReturnsAsync(checkoutUrl);
 
     // Act
     var result = await _controller.CreateCheckoutSession(
-        new CreateCheckoutDto { PlanId = null, ClientRequestId = "req-1" });
+        new CreateCheckoutDto { PlanId = null, ClientRequestId = clientRequestId });
 
     // Assert
     var okResult = Assert.IsType<OkObjectResult>(result);
     Assert.NotNull(okResult.Value);
     Assert.Equal(checkoutUrl, GetProperty(okResult.Value!, "checkoutUrl"));
-    _mockPaymentService.Verify(x => x.CreateCheckoutSessionAsync(1, "price_default", "req-1"), Times.Once);
+    _mockPaymentService.Verify(x => x.CreateCheckoutSessionAsync(1, "price_default", clientRequestId), Times.Once);
     _mockSubscriptionService.Verify(x => x.GetPlanByIdAsync(It.IsAny<int>()), Times.Never);
   }
 
@@ -248,6 +249,26 @@ public class SubscriptionControllerTests : IDisposable
     var okResult = Assert.IsType<OkObjectResult>(result);
     Assert.Equal(checkoutUrl, GetProperty(okResult.Value!, "checkoutUrl"));
     _mockSubscriptionService.Verify(x => x.GetAvailablePlansAsync(), Times.Never);
+  }
+
+  [Theory]
+  [InlineData("not-a-uuid")]
+  [InlineData("checkout-1-injected'; DROP TABLE")]
+  public async Task CreateCheckoutSession_WithNonUuidClientRequestId_ShouldReturnBadRequest(string clientRequestId)
+  {
+    // Arrange - ClientRequestId feeds Stripe's idempotency key (255-char cap); arbitrary
+    // client strings must be rejected before any Stripe call.
+    var result = await _controller.CreateCheckoutSession(new CreateCheckoutDto
+    {
+      ClientRequestId = clientRequestId
+    });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status400BadRequest, problem.Status);
+    _mockPaymentService.Verify(x => x.CreateCheckoutSessionAsync(
+        It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
   }
 
   [Fact]
@@ -570,7 +591,7 @@ public class SubscriptionControllerTests : IDisposable
     Assert.True((bool)GetProperty(okResult.Value!, "cancelAtPeriodEnd")!);
     Assert.Equal(subscription.CurrentPeriodEnd, GetProperty(okResult.Value!, "activeUntil"));
     _mockPaymentService.Verify(x => x.CancelAtPeriodEndAsync(It.IsAny<string>()), Times.Never);
-    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(It.IsAny<int>()), Times.Never);
+    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(It.IsAny<string>()), Times.Never);
   }
 
   [Fact]
@@ -585,7 +606,7 @@ public class SubscriptionControllerTests : IDisposable
     _mockPaymentService.Setup(x => x.CancelAtPeriodEndAsync("sub_test123"))
         .Callback(() => callOrder.Add("stripe"))
         .Returns(Task.CompletedTask);
-    _mockSubscriptionService.Setup(x => x.MarkCancellationRequestedAsync(1))
+    _mockSubscriptionService.Setup(x => x.MarkCancellationRequestedAsync("sub_test123"))
         .Callback(() => callOrder.Add("local"))
         .ReturnsAsync(subscription);
 
@@ -599,7 +620,7 @@ public class SubscriptionControllerTests : IDisposable
     Assert.Equal(subscription.CurrentPeriodEnd, GetProperty(okResult.Value!, "activeUntil"));
 
     _mockPaymentService.Verify(x => x.CancelAtPeriodEndAsync("sub_test123"), Times.Once);
-    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(1), Times.Once);
+    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync("sub_test123"), Times.Once);
     // Stripe must accept the cancellation before the local flag is persisted
     Assert.Equal(new[] { "stripe", "local" }, callOrder);
   }
@@ -621,7 +642,7 @@ public class SubscriptionControllerTests : IDisposable
     var objectResult = Assert.IsType<ObjectResult>(result);
     var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
     Assert.Equal(StatusCodes.Status500InternalServerError, problem.Status);
-    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(It.IsAny<int>()), Times.Never);
+    _mockSubscriptionService.Verify(x => x.MarkCancellationRequestedAsync(It.IsAny<string>()), Times.Never);
   }
 
   #endregion

--- a/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
+++ b/api.Tests/Unit/Controllers/SubscriptionControllerTests.cs
@@ -343,9 +343,12 @@ public class SubscriptionControllerTests : IDisposable
   [Fact]
   public async Task CompleteCheckout_WhenSessionNotFoundOnStripe_ShouldReturnNotFound()
   {
-    // Arrange
+    // Arrange - only a genuine resource_missing maps to 404
     _mockPaymentService.Setup(x => x.GetCheckoutSessionAsync("cs_missing"))
-        .ThrowsAsync(new Stripe.StripeException("No such checkout session"));
+        .ThrowsAsync(new Stripe.StripeException("No such checkout session")
+        {
+          StripeError = new Stripe.StripeError { Code = "resource_missing" }
+        });
 
     // Act
     var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "cs_missing" });
@@ -354,6 +357,23 @@ public class SubscriptionControllerTests : IDisposable
     var objectResult = Assert.IsType<ObjectResult>(result);
     var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
     Assert.Equal(StatusCodes.Status404NotFound, problem.Status);
+  }
+
+  [Fact]
+  public async Task CompleteCheckout_WhenStripeFailsTransiently_ShouldReturn500NotNotFound()
+  {
+    // Arrange - a Stripe outage right after the user PAID must read as retryable, not as
+    // "your session doesn't exist"
+    _mockPaymentService.Setup(x => x.GetCheckoutSessionAsync("cs_1"))
+        .ThrowsAsync(new Stripe.StripeException("Stripe unavailable"));
+
+    // Act
+    var result = await _controller.CompleteCheckout(new CompleteCheckoutDto { SessionId = "cs_1" });
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status500InternalServerError, problem.Status);
   }
 
   [Fact]
@@ -721,7 +741,7 @@ public class SubscriptionControllerTests : IDisposable
   }
 
   [Fact]
-  public async Task CreatePortalSession_WithNoActiveSubscription_ShouldReturnBadRequest()
+  public async Task CreatePortalSession_WithNoActiveSubscription_ShouldReturnNotFound()
   {
     // Arrange
     _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
@@ -731,10 +751,29 @@ public class SubscriptionControllerTests : IDisposable
     var result = await _controller.CreatePortalSession();
 
     // Assert
-    var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
-    var response = badRequestResult.Value;
-    Assert.NotNull(response);
-    Assert.Equal("No active subscription found", GetProperty(response!, "error"));
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status404NotFound, problem.Status);
+  }
+
+  [Fact]
+  public async Task CreatePortalSession_WhenStripeFails_ShouldReturn500()
+  {
+    // Arrange - portal failure is server-side (Stripe outage, unconfigured Dashboard
+    // portal), not a client error
+    var subscription = CreateUserSubscription(1);
+    _mockSubscriptionService.Setup(x => x.GetActiveSubscriptionAsync(1))
+        .ReturnsAsync(subscription);
+    _mockPaymentService.Setup(x => x.CreatePortalSessionAsync(It.IsAny<string>()))
+        .ThrowsAsync(new Stripe.StripeException("portal not configured"));
+
+    // Act
+    var result = await _controller.CreatePortalSession();
+
+    // Assert
+    var objectResult = Assert.IsType<ObjectResult>(result);
+    var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+    Assert.Equal(StatusCodes.Status500InternalServerError, problem.Status);
   }
 
   [Fact]

--- a/api.Tests/Unit/Services/StripeHealthCheckServiceTests.cs
+++ b/api.Tests/Unit/Services/StripeHealthCheckServiceTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RadioWash.Api.Services.Implementations;
+using Xunit;
+
+namespace RadioWash.Api.Tests.Unit.Services;
+
+/// <summary>
+/// Tests ValidateConfigurationAsync: key presence, key prefix shape, and the
+/// production guard that refuses test-mode keys. Connectivity testing hits the
+/// live Stripe API and is not unit tested.
+/// </summary>
+public class StripeHealthCheckServiceTests
+{
+  private readonly Mock<IHostEnvironment> _mockEnvironment;
+  private readonly Mock<ILogger<StripeHealthCheckService>> _mockLogger;
+
+  public StripeHealthCheckServiceTests()
+  {
+    _mockEnvironment = new Mock<IHostEnvironment>();
+    _mockLogger = new Mock<ILogger<StripeHealthCheckService>>();
+  }
+
+  private StripeHealthCheckService CreateService(
+      string environmentName,
+      string? secretKey,
+      string? webhookSecret,
+      string? publishableKey = null)
+  {
+    var configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+          ["Stripe:SecretKey"] = secretKey,
+          ["Stripe:WebhookSecret"] = webhookSecret,
+          ["Stripe:PublishableKey"] = publishableKey
+        })
+        .Build();
+
+    // IsProduction() is an extension method over EnvironmentName
+    _mockEnvironment.SetupGet(x => x.EnvironmentName).Returns(environmentName);
+
+    return new StripeHealthCheckService(configuration, _mockEnvironment.Object, _mockLogger.Object);
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithLiveKeysInProduction_ReturnsTrue()
+  {
+    var service = CreateService(
+        Environments.Production,
+        secretKey: "sk_live_123",
+        webhookSecret: "whsec_123",
+        publishableKey: "pk_live_123");
+
+    Assert.True(await service.ValidateConfigurationAsync());
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithTestSecretKeyInProduction_ReturnsFalse()
+  {
+    var service = CreateService(
+        Environments.Production,
+        secretKey: "sk_test_123",
+        webhookSecret: "whsec_123");
+
+    Assert.False(await service.ValidateConfigurationAsync());
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithTestPublishableKeyInProduction_ReturnsFalse()
+  {
+    var service = CreateService(
+        Environments.Production,
+        secretKey: "sk_live_123",
+        webhookSecret: "whsec_123",
+        publishableKey: "pk_test_123");
+
+    Assert.False(await service.ValidateConfigurationAsync());
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithTestKeysInDevelopment_ReturnsTrue()
+  {
+    var service = CreateService(
+        Environments.Development,
+        secretKey: "sk_test_123",
+        webhookSecret: "whsec_123",
+        publishableKey: "pk_test_123");
+
+    Assert.True(await service.ValidateConfigurationAsync());
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithMissingSecretKey_ReturnsFalse()
+  {
+    var service = CreateService(
+        Environments.Development,
+        secretKey: null,
+        webhookSecret: "whsec_123");
+
+    Assert.False(await service.ValidateConfigurationAsync());
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithMissingWebhookSecret_ReturnsFalse()
+  {
+    var service = CreateService(
+        Environments.Development,
+        secretKey: "sk_test_123",
+        webhookSecret: null);
+
+    Assert.False(await service.ValidateConfigurationAsync());
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithMalformedSecretKeyPrefix_ReturnsFalse()
+  {
+    var service = CreateService(
+        Environments.Development,
+        secretKey: "not_a_stripe_key",
+        webhookSecret: "whsec_123");
+
+    Assert.False(await service.ValidateConfigurationAsync());
+  }
+
+  [Fact]
+  public async Task ValidateConfigurationAsync_WithMalformedWebhookSecretPrefix_ReturnsFalse()
+  {
+    var service = CreateService(
+        Environments.Development,
+        secretKey: "sk_test_123",
+        webhookSecret: "not_a_webhook_secret");
+
+    Assert.False(await service.ValidateConfigurationAsync());
+  }
+}

--- a/api.Tests/Unit/Services/StripePaymentServiceTests.cs
+++ b/api.Tests/Unit/Services/StripePaymentServiceTests.cs
@@ -10,8 +10,9 @@ using Xunit;
 namespace RadioWash.Api.Tests.Unit.Services;
 
 /// <summary>
-/// Tests HandleWebhookAsync orchestration: signature verification, idempotency claiming,
-/// processor dispatch, success/failure marking, and retry scheduling. Per-event-type
+/// Tests HandleWebhookAsync orchestration (signature verification, idempotency claiming,
+/// processor dispatch, success/failure marking, retry scheduling) plus the Stripe client
+/// calls behind checkout, portal, cancel-at-period-end, and session retrieval. Per-event-type
 /// dispatch behavior is covered by the StripeWebhookProcessor tests.
 /// </summary>
 public class StripePaymentServiceTests
@@ -19,12 +20,16 @@ public class StripePaymentServiceTests
   private const string Payload = "{\"id\":\"evt_test\"}";
   private const string Signature = "test_signature";
   private const string WebhookSecret = "whsec_123";
+  private const string FrontendUrl = "https://example.com";
 
   private readonly Mock<IConfiguration> _mockConfiguration;
   private readonly Mock<IEventUtility> _mockEventUtility;
   private readonly Mock<IIdempotencyService> _mockIdempotencyService;
   private readonly Mock<IWebhookRetryService> _mockWebhookRetryService;
   private readonly Mock<IWebhookProcessor> _mockWebhookProcessor;
+  private readonly Mock<Stripe.Checkout.SessionService> _mockCheckoutSessionService;
+  private readonly Mock<Stripe.BillingPortal.SessionService> _mockPortalSessionService;
+  private readonly Mock<Stripe.SubscriptionService> _mockStripeSubscriptionService;
   private readonly Mock<ILogger<StripePaymentService>> _mockLogger;
   private readonly StripePaymentService _stripePaymentService;
 
@@ -35,11 +40,14 @@ public class StripePaymentServiceTests
     _mockIdempotencyService = new Mock<IIdempotencyService>();
     _mockWebhookRetryService = new Mock<IWebhookRetryService>();
     _mockWebhookProcessor = new Mock<IWebhookProcessor>();
+    _mockCheckoutSessionService = new Mock<Stripe.Checkout.SessionService>();
+    _mockPortalSessionService = new Mock<Stripe.BillingPortal.SessionService>();
+    _mockStripeSubscriptionService = new Mock<Stripe.SubscriptionService>();
     _mockLogger = new Mock<ILogger<StripePaymentService>>();
 
     _mockConfiguration.Setup(x => x["Stripe:SecretKey"]).Returns("sk_test_123");
     _mockConfiguration.Setup(x => x["Stripe:WebhookSecret"]).Returns(WebhookSecret);
-    _mockConfiguration.Setup(x => x["FrontendUrl"]).Returns("https://example.com");
+    _mockConfiguration.Setup(x => x["FrontendUrl"]).Returns(FrontendUrl);
 
     _stripePaymentService = new StripePaymentService(
         _mockConfiguration.Object,
@@ -47,6 +55,9 @@ public class StripePaymentServiceTests
         _mockIdempotencyService.Object,
         _mockWebhookRetryService.Object,
         _mockWebhookProcessor.Object,
+        _mockCheckoutSessionService.Object,
+        _mockPortalSessionService.Object,
+        _mockStripeSubscriptionService.Object,
         _mockLogger.Object
     );
   }
@@ -321,6 +332,178 @@ public class StripePaymentServiceTests
         () => _stripePaymentService.HandleWebhookAsync(Payload, Signature));
 
     _mockEventUtility.Verify(x => x.ConstructEvent(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+  }
+
+  #endregion
+
+  #region CreateCheckoutSessionAsync
+
+  [Fact]
+  public async Task CreateCheckoutSessionAsync_BuildsSessionOptionsFromPlanAndUser()
+  {
+    // Arrange
+    Stripe.Checkout.SessionCreateOptions? capturedOptions = null;
+    _mockCheckoutSessionService
+        .Setup(x => x.CreateAsync(
+            It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+            It.IsAny<RequestOptions>(),
+            It.IsAny<CancellationToken>()))
+        .Callback<Stripe.Checkout.SessionCreateOptions, RequestOptions, CancellationToken>(
+            (options, _, _) => capturedOptions = options)
+        .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_1", Url = "https://checkout.stripe.com/x" });
+
+    // Act
+    var url = await _stripePaymentService.CreateCheckoutSessionAsync(42, "price_abc");
+
+    // Assert
+    Assert.Equal("https://checkout.stripe.com/x", url);
+    Assert.NotNull(capturedOptions);
+    // Literal {CHECKOUT_SESSION_ID} placeholder is substituted by Stripe, not by us
+    Assert.Equal($"{FrontendUrl}/subscription/success?session_id={{CHECKOUT_SESSION_ID}}", capturedOptions!.SuccessUrl);
+    Assert.Equal($"{FrontendUrl}/subscription/cancel", capturedOptions.CancelUrl);
+    Assert.Equal("subscription", capturedOptions.Mode);
+    var lineItem = Assert.Single(capturedOptions.LineItems);
+    Assert.Equal("price_abc", lineItem.Price);
+    // userId metadata must be on both the session and the subscription it creates
+    Assert.Equal("42", capturedOptions.Metadata["userId"]);
+    Assert.Equal("42", capturedOptions.SubscriptionData.Metadata["userId"]);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSessionAsync_WithClientRequestId_SendsIdempotencyKey()
+  {
+    // Arrange
+    RequestOptions? capturedRequestOptions = null;
+    _mockCheckoutSessionService
+        .Setup(x => x.CreateAsync(
+            It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+            It.IsAny<RequestOptions>(),
+            It.IsAny<CancellationToken>()))
+        .Callback<Stripe.Checkout.SessionCreateOptions, RequestOptions, CancellationToken>(
+            (_, requestOptions, _) => capturedRequestOptions = requestOptions)
+        .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_1", Url = "https://checkout.stripe.com/x" });
+
+    // Act
+    await _stripePaymentService.CreateCheckoutSessionAsync(42, "price_abc", "abc");
+
+    // Assert
+    Assert.NotNull(capturedRequestOptions);
+    Assert.Equal("checkout-42-abc", capturedRequestOptions!.IdempotencyKey);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSessionAsync_WithoutClientRequestId_SendsNoRequestOptions()
+  {
+    // Arrange
+    var requestOptionsCaptured = false;
+    RequestOptions? capturedRequestOptions = null;
+    _mockCheckoutSessionService
+        .Setup(x => x.CreateAsync(
+            It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+            It.IsAny<RequestOptions>(),
+            It.IsAny<CancellationToken>()))
+        .Callback<Stripe.Checkout.SessionCreateOptions, RequestOptions, CancellationToken>(
+            (_, requestOptions, _) => { requestOptionsCaptured = true; capturedRequestOptions = requestOptions; })
+        .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_1", Url = "https://checkout.stripe.com/x" });
+
+    // Act
+    await _stripePaymentService.CreateCheckoutSessionAsync(42, "price_abc", clientRequestId: null);
+
+    // Assert - no idempotency key means no RequestOptions at all
+    Assert.True(requestOptionsCaptured);
+    Assert.Null(capturedRequestOptions);
+  }
+
+  [Fact]
+  public async Task CreateCheckoutSessionAsync_WhenSessionHasNoUrl_ThrowsInvalidOperationException()
+  {
+    // Arrange - a session without a redirect URL is unusable for the frontend
+    _mockCheckoutSessionService
+        .Setup(x => x.CreateAsync(
+            It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+            It.IsAny<RequestOptions>(),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_no_url", Url = null });
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _stripePaymentService.CreateCheckoutSessionAsync(42, "price_abc"));
+    Assert.Contains("cs_no_url", exception.Message);
+  }
+
+  #endregion
+
+  #region CancelAtPeriodEndAsync / GetCheckoutSessionAsync / CreatePortalSessionAsync
+
+  [Fact]
+  public async Task CancelAtPeriodEndAsync_UpdatesStripeSubscriptionWithCancelFlag()
+  {
+    // Arrange
+    _mockStripeSubscriptionService
+        .Setup(x => x.UpdateAsync(
+            "sub_1",
+            It.IsAny<SubscriptionUpdateOptions>(),
+            It.IsAny<RequestOptions>(),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new Subscription { Id = "sub_1" });
+
+    // Act
+    await _stripePaymentService.CancelAtPeriodEndAsync("sub_1");
+
+    // Assert
+    _mockStripeSubscriptionService.Verify(x => x.UpdateAsync(
+        "sub_1",
+        It.Is<SubscriptionUpdateOptions>(o => o.CancelAtPeriodEnd == true),
+        It.IsAny<RequestOptions>(),
+        It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task GetCheckoutSessionAsync_RetrievesSessionWithSubscriptionExpanded()
+  {
+    // Arrange
+    var session = new Stripe.Checkout.Session { Id = "cs_1" };
+    _mockCheckoutSessionService
+        .Setup(x => x.GetAsync(
+            "cs_1",
+            It.IsAny<Stripe.Checkout.SessionGetOptions>(),
+            It.IsAny<RequestOptions>(),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(session);
+
+    // Act
+    var result = await _stripePaymentService.GetCheckoutSessionAsync("cs_1");
+
+    // Assert
+    Assert.Same(session, result);
+    _mockCheckoutSessionService.Verify(x => x.GetAsync(
+        "cs_1",
+        It.Is<Stripe.Checkout.SessionGetOptions>(o => o.Expand.Contains("subscription")),
+        It.IsAny<RequestOptions>(),
+        It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task CreatePortalSessionAsync_CreatesPortalSessionForCustomer()
+  {
+    // Arrange
+    _mockPortalSessionService
+        .Setup(x => x.CreateAsync(
+            It.IsAny<Stripe.BillingPortal.SessionCreateOptions>(),
+            It.IsAny<RequestOptions>(),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new Stripe.BillingPortal.Session { Url = "https://billing.stripe.com/p/session" });
+
+    // Act
+    var url = await _stripePaymentService.CreatePortalSessionAsync("cus_1");
+
+    // Assert
+    Assert.Equal("https://billing.stripe.com/p/session", url);
+    _mockPortalSessionService.Verify(x => x.CreateAsync(
+        It.Is<Stripe.BillingPortal.SessionCreateOptions>(o =>
+            o.Customer == "cus_1" && o.ReturnUrl == $"{FrontendUrl}/dashboard"),
+        It.IsAny<RequestOptions>(),
+        It.IsAny<CancellationToken>()), Times.Once);
   }
 
   #endregion

--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -759,7 +759,7 @@ public class SubscriptionServiceTests
         .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
         .ReturnsAsync(false);
-    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => s);
     _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
         .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
@@ -769,7 +769,7 @@ public class SubscriptionServiceTests
 
     // Assert
     Assert.True(result.CancelAtPeriodEnd);
-    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.Is<UserSubscription>(
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.Is<UserSubscription>(
         s => s.CancelAtPeriodEnd)), Times.Once);
   }
 

--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -421,19 +421,20 @@ public class SubscriptionServiceTests
   }
 
   [Fact]
-  public async Task MarkCancellationRequestedAsync_WithValidUser_SetsOnlyCancelAtPeriodEnd()
+  public async Task MarkCancellationRequestedAsync_WithValidSubscription_SetsOnlyCancelAtPeriodEnd()
   {
     // Arrange
-    var userId = 1;
-    var subscription = CreateUserSubscription(userId);
+    var stripeSubscriptionId = "sub_cancel_me";
+    var subscription = CreateUserSubscription(1);
+    subscription.StripeSubscriptionId = stripeSubscriptionId;
 
-    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
         .ReturnsAsync(subscription);
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => s);
 
     // Act
-    var result = await _subscriptionService.MarkCancellationRequestedAsync(userId);
+    var result = await _subscriptionService.MarkCancellationRequestedAsync(stripeSubscriptionId);
 
     // Assert - the user paid for the rest of the period: status stays active, CanceledAt
     // stays null, and sync configs keep running. customer.subscription.deleted deactivates.
@@ -452,15 +453,15 @@ public class SubscriptionServiceTests
   public async Task MarkCancellationRequestedAsync_WithNoSubscription_Throws()
   {
     // Arrange
-    var userId = 404;
-    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
+    var stripeSubscriptionId = "sub_unknown";
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId))
         .ReturnsAsync((UserSubscription?)null);
 
     // Act & Assert
     var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-        () => _subscriptionService.MarkCancellationRequestedAsync(userId));
+        () => _subscriptionService.MarkCancellationRequestedAsync(stripeSubscriptionId));
 
-    Assert.Contains($"No subscription found for user {userId}", exception.Message);
+    Assert.Contains($"No subscription found with Stripe id {stripeSubscriptionId}", exception.Message);
     _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()), Times.Never);
   }
 

--- a/api.Tests/Unit/Services/SubscriptionServiceTests.cs
+++ b/api.Tests/Unit/Services/SubscriptionServiceTests.cs
@@ -421,34 +421,47 @@ public class SubscriptionServiceTests
   }
 
   [Fact]
-  public async Task CancelSubscriptionAsync_WithValidUser_ShouldCancelAndDisableSyncs()
+  public async Task MarkCancellationRequestedAsync_WithValidUser_SetsOnlyCancelAtPeriodEnd()
   {
     // Arrange
     var userId = 1;
     var subscription = CreateUserSubscription(userId);
-    var syncConfigs = new List<PlaylistSyncConfig>
-        {
-            new PlaylistSyncConfig { Id = 1, UserId = userId, IsActive = true }
-        };
 
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
         .ReturnsAsync(subscription);
-    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetEnabledByUserIdAsync(userId))
-        .ReturnsAsync(syncConfigs);
     _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
         .ReturnsAsync((UserSubscription s) => s);
-    _mockUnitOfWork.Setup(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()))
-        .Returns(Task.CompletedTask);
 
     // Act
-    var result = await _subscriptionService.CancelSubscriptionAsync(userId);
+    var result = await _subscriptionService.MarkCancellationRequestedAsync(userId);
 
-    // Assert
+    // Assert - the user paid for the rest of the period: status stays active, CanceledAt
+    // stays null, and sync configs keep running. customer.subscription.deleted deactivates.
     Assert.NotNull(result);
-    Assert.Equal(SubscriptionStatus.Canceled, result.Status);
-    Assert.NotNull(result.CanceledAt);
+    Assert.True(result.CancelAtPeriodEnd);
+    Assert.Equal(SubscriptionStatus.Active, result.Status);
+    Assert.Null(result.CanceledAt);
 
-    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(1, AutoDisableReason.SubscriptionInactive), Times.Once);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.Is<UserSubscription>(
+        s => s.CancelAtPeriodEnd && s.Status == SubscriptionStatus.Active)), Times.Once);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.DisableConfigAsync(It.IsAny<int>(), It.IsAny<string?>()), Times.Never);
+    _mockUnitOfWork.Verify(x => x.SyncConfigs.GetEnabledByUserIdAsync(It.IsAny<int>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task MarkCancellationRequestedAsync_WithNoSubscription_Throws()
+  {
+    // Arrange
+    var userId = 404;
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByUserIdAsync(userId))
+        .ReturnsAsync((UserSubscription?)null);
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _subscriptionService.MarkCancellationRequestedAsync(userId));
+
+    Assert.Contains($"No subscription found for user {userId}", exception.Message);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()), Times.Never);
   }
 
   [Fact]
@@ -678,6 +691,86 @@ public class SubscriptionServiceTests
 
     _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(existing), Times.Once);
     _mockUnitOfWork.Verify(x => x.UserSubscriptions.TryCreateAsync(It.IsAny<UserSubscription>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WithExistingLocalRow_PersistsCancelAtPeriodEnd()
+  {
+    // Arrange - Stripe owns the flag; the sync propagates it onto the local row
+    var existing = CreateUserSubscription(1);
+    Assert.False(existing.CancelAtPeriodEnd);
+
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_123", "cus_123", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(29));
+    stripeSubscription.CancelAtPeriodEnd = true;
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_123"))
+        .ReturnsAsync(existing);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert
+    Assert.True(result.CancelAtPeriodEnd);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.UpdateAsync(It.Is<UserSubscription>(
+        s => s.CancelAtPeriodEnd)), Times.Once);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_WhenStripeClearsCancelAtPeriodEnd_ClearsLocalFlag()
+  {
+    // Arrange - a portal-side "resume" clears cancel_at_period_end on Stripe's side
+    var existing = CreateUserSubscription(1);
+    existing.CancelAtPeriodEnd = true;
+
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_123", "cus_123", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(29));
+    stripeSubscription.CancelAtPeriodEnd = false;
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_123"))
+        .ReturnsAsync(existing);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.UpdateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert
+    Assert.False(result.CancelAtPeriodEnd);
+  }
+
+  [Fact]
+  public async Task SyncFromStripeAsync_CreatingNewRow_PersistsCancelAtPeriodEnd()
+  {
+    // Arrange
+    var userId = 43;
+    var stripeSubscription = CreateStripeSubscription(
+        "sub_new_cape", "cus_new", SubscriptionStatus.Active, "price_x",
+        DateTime.UtcNow, DateTime.UtcNow.AddDays(30), userId);
+    stripeSubscription.CancelAtPeriodEnd = true;
+
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.GetByStripeSubscriptionIdAsync("sub_new_cape"))
+        .ReturnsAsync((UserSubscription?)null);
+    _mockUnitOfWork.Setup(x => x.SubscriptionPlans.GetByStripePriceIdAsync("price_x"))
+        .ReturnsAsync(CreateSubscriptionPlan(1, "Pro"));
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.HasActiveSubscriptionAsync(userId))
+        .ReturnsAsync(false);
+    _mockUnitOfWork.Setup(x => x.UserSubscriptions.CreateAsync(It.IsAny<UserSubscription>()))
+        .ReturnsAsync((UserSubscription s) => s);
+    _mockUnitOfWork.Setup(x => x.SyncConfigs.GetAutoDisabledByUserIdAsync(userId, AutoDisableReason.SubscriptionInactive))
+        .ReturnsAsync(Array.Empty<PlaylistSyncConfig>());
+
+    // Act
+    var result = await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+
+    // Assert
+    Assert.True(result.CancelAtPeriodEnd);
+    _mockUnitOfWork.Verify(x => x.UserSubscriptions.CreateAsync(It.Is<UserSubscription>(
+        s => s.CancelAtPeriodEnd)), Times.Once);
   }
 
   [Fact]

--- a/api/Controllers/SubscriptionController.cs
+++ b/api/Controllers/SubscriptionController.cs
@@ -115,6 +115,16 @@ public class SubscriptionController : AuthenticatedControllerBase
         type: "https://radiowash.app/problems/already-subscribed");
     }
 
+    // ClientRequestId feeds Stripe's idempotency key (capped at 255 chars), so arbitrary
+    // client strings must not pass through — the frontend always sends crypto.randomUUID().
+    if (dto.ClientRequestId != null && !Guid.TryParse(dto.ClientRequestId, out _))
+    {
+      return Problem(
+        title: "Invalid request id",
+        detail: "clientRequestId must be a UUID.",
+        statusCode: StatusCodes.Status400BadRequest);
+    }
+
     // The Stripe price is resolved server-side from the local plan — client-supplied price
     // ids are never forwarded to Stripe.
     var plan = dto.PlanId.HasValue
@@ -149,7 +159,7 @@ public class SubscriptionController : AuthenticatedControllerBase
   // the session (and subscription) from Stripe and syncs it locally, so activation doesn't
   // depend on the webhook having already arrived. Idempotent.
   [HttpPost("checkout/complete")]
-  [EnableRateLimiting("checkout")]
+  [EnableRateLimiting("checkout-complete")]
   public async Task<ActionResult> CompleteCheckout([FromBody] CompleteCheckoutDto dto)
   {
     var userId = GetCurrentUserId();
@@ -276,9 +286,11 @@ public class SubscriptionController : AuthenticatedControllerBase
     try
     {
       // Stripe first: if this fails the user stays subscribed on both sides. The local
-      // flag follows only after Stripe accepted the cancellation.
+      // flag follows only after Stripe accepted the cancellation, and is keyed on the same
+      // Stripe subscription the cancel targeted — not re-resolved per user, which could
+      // pick a different row in the (alerted) duplicate-subscription state.
       await _paymentService.CancelAtPeriodEndAsync(subscription.StripeSubscriptionId);
-      await _subscriptionService.MarkCancellationRequestedAsync(userId);
+      await _subscriptionService.MarkCancellationRequestedAsync(subscription.StripeSubscriptionId);
 
       return Ok(new
       {

--- a/api/Controllers/SubscriptionController.cs
+++ b/api/Controllers/SubscriptionController.cs
@@ -16,16 +16,19 @@ public class SubscriptionController : AuthenticatedControllerBase
 {
   private readonly ISubscriptionService _subscriptionService;
   private readonly IPaymentService _paymentService;
+  private readonly IConfiguration _configuration;
   private readonly ILogger<SubscriptionController> _logger;
 
   public SubscriptionController(
       RadioWashDbContext dbContext,
       ISubscriptionService subscriptionService,
       IPaymentService paymentService,
+      IConfiguration configuration,
       ILogger<SubscriptionController> logger) : base(dbContext, logger)
   {
     _subscriptionService = subscriptionService;
     _paymentService = paymentService;
+    _configuration = configuration;
     _logger = logger;
   }
 
@@ -68,6 +71,7 @@ public class SubscriptionController : AuthenticatedControllerBase
       CurrentPeriodStart = subscription.CurrentPeriodStart,
       CurrentPeriodEnd = subscription.CurrentPeriodEnd,
       CanceledAt = subscription.CanceledAt,
+      CancelAtPeriodEnd = subscription.CancelAtPeriodEnd,
       Plan = new SubscriptionPlanDto
       {
         Id = subscription.Plan.Id,
@@ -92,16 +96,109 @@ public class SubscriptionController : AuthenticatedControllerBase
   {
     var userId = GetCurrentUserId();
 
+    // Kill switch: lets checkout be disabled via an app-settings change without a deploy.
+    if (!_configuration.GetValue("Features:CheckoutEnabled", true))
+    {
+      return Problem(
+        title: "Checkout disabled",
+        detail: "Subscriptions are temporarily unavailable. Please try again later.",
+        statusCode: StatusCodes.Status503ServiceUnavailable,
+        type: "https://radiowash.app/problems/checkout-disabled");
+    }
+
+    if (await _subscriptionService.HasActiveSubscriptionAsync(userId))
+    {
+      return Problem(
+        title: "Already subscribed",
+        detail: "You already have an active subscription.",
+        statusCode: StatusCodes.Status409Conflict,
+        type: "https://radiowash.app/problems/already-subscribed");
+    }
+
+    // The Stripe price is resolved server-side from the local plan — client-supplied price
+    // ids are never forwarded to Stripe.
+    var plan = dto.PlanId.HasValue
+      ? await _subscriptionService.GetPlanByIdAsync(dto.PlanId.Value)
+      : (await _subscriptionService.GetAvailablePlansAsync()).FirstOrDefault();
+
+    if (plan is not { IsActive: true } || string.IsNullOrEmpty(plan.StripePriceId))
+    {
+      return Problem(
+        title: "Plan unavailable",
+        detail: "The requested subscription plan is not available.",
+        statusCode: StatusCodes.Status400BadRequest,
+        type: "https://radiowash.app/problems/plan-unavailable");
+    }
+
     try
     {
-      var checkoutUrl = await _paymentService.CreateCheckoutSessionAsync(userId, dto.PlanPriceId);
+      var checkoutUrl = await _paymentService.CreateCheckoutSessionAsync(userId, plan.StripePriceId, dto.ClientRequestId);
       return Ok(new { checkoutUrl });
     }
     catch (Exception ex)
     {
       _logger.LogError(ex, "Failed to create checkout session for user {UserId}", userId);
-      return BadRequest(new { error = "Failed to create checkout session" });
+      return Problem(
+        title: "Checkout failed",
+        detail: "Could not start checkout. Please try again.",
+        statusCode: StatusCodes.Status500InternalServerError);
     }
+  }
+
+  // Called by the success page with the session_id Stripe appended to the redirect. Pulls
+  // the session (and subscription) from Stripe and syncs it locally, so activation doesn't
+  // depend on the webhook having already arrived. Idempotent.
+  [HttpPost("checkout/complete")]
+  [EnableRateLimiting("checkout")]
+  public async Task<ActionResult> CompleteCheckout([FromBody] CompleteCheckoutDto dto)
+  {
+    var userId = GetCurrentUserId();
+
+    if (string.IsNullOrEmpty(dto.SessionId))
+    {
+      return Problem(
+        title: "Missing session id",
+        detail: "A checkout session id is required.",
+        statusCode: StatusCodes.Status400BadRequest);
+    }
+
+    Stripe.Checkout.Session session;
+    try
+    {
+      session = await _paymentService.GetCheckoutSessionAsync(dto.SessionId);
+    }
+    catch (Stripe.StripeException ex)
+    {
+      _logger.LogWarning(ex, "Checkout session {SessionId} could not be retrieved for user {UserId}", dto.SessionId, userId);
+      return Problem(
+        title: "Unknown checkout session",
+        detail: "The checkout session could not be found.",
+        statusCode: StatusCodes.Status404NotFound);
+    }
+
+    if (session.Metadata == null
+        || !session.Metadata.TryGetValue("userId", out var sessionUserId)
+        || sessionUserId != userId.ToString())
+    {
+      _logger.LogWarning("User {UserId} attempted to complete checkout session {SessionId} belonging to someone else",
+        userId, dto.SessionId);
+      return Problem(
+        title: "Forbidden",
+        detail: "This checkout session does not belong to the current user.",
+        statusCode: StatusCodes.Status403Forbidden);
+    }
+
+    if (session.Subscription != null)
+    {
+      await _subscriptionService.SyncFromStripeAsync(session.Subscription);
+    }
+    else
+    {
+      _logger.LogInformation("Checkout session {SessionId} has no subscription yet (payment may still be processing)",
+        dto.SessionId);
+    }
+
+    return Ok(await BuildStatusPayloadAsync(userId));
   }
 
   [HttpPost("portal")]
@@ -129,19 +226,54 @@ public class SubscriptionController : AuthenticatedControllerBase
   }
 
   [HttpPost("cancel")]
+  [EnableRateLimiting("checkout")]
   public async Task<ActionResult> CancelSubscription()
   {
     var userId = GetCurrentUserId();
 
+    var subscription = await _subscriptionService.GetActiveSubscriptionAsync(userId);
+    if (subscription == null
+        || !Models.Domain.SubscriptionStatusMapper.IsEntitled(subscription.Status)
+        || string.IsNullOrEmpty(subscription.StripeSubscriptionId))
+    {
+      return Problem(
+        title: "No active subscription",
+        detail: "There is no active subscription to cancel.",
+        statusCode: StatusCodes.Status404NotFound);
+    }
+
+    if (subscription.CancelAtPeriodEnd)
+    {
+      // Already scheduled — idempotent success.
+      return Ok(new
+      {
+        message = "Subscription is already scheduled to cancel at the end of the billing period",
+        activeUntil = subscription.CurrentPeriodEnd,
+        cancelAtPeriodEnd = true
+      });
+    }
+
     try
     {
-      await _subscriptionService.CancelSubscriptionAsync(userId);
-      return Ok(new { message = "Subscription canceled successfully" });
+      // Stripe first: if this fails the user stays subscribed on both sides. The local
+      // flag follows only after Stripe accepted the cancellation.
+      await _paymentService.CancelAtPeriodEndAsync(subscription.StripeSubscriptionId);
+      await _subscriptionService.MarkCancellationRequestedAsync(userId);
+
+      return Ok(new
+      {
+        message = "Subscription will cancel at the end of the current billing period",
+        activeUntil = subscription.CurrentPeriodEnd,
+        cancelAtPeriodEnd = true
+      });
     }
     catch (Exception ex)
     {
       _logger.LogError(ex, "Failed to cancel subscription for user {UserId}", userId);
-      return BadRequest(new { error = "Failed to cancel subscription" });
+      return Problem(
+        title: "Cancellation failed",
+        detail: "Could not cancel the subscription. Please try again.",
+        statusCode: StatusCodes.Status500InternalServerError);
     }
   }
 
@@ -182,9 +314,23 @@ public class SubscriptionController : AuthenticatedControllerBase
   public async Task<ActionResult> GetSubscriptionStatus()
   {
     var userId = GetCurrentUserId();
-    var hasActiveSubscription = await _subscriptionService.HasActiveSubscriptionAsync(userId);
+    return Ok(await BuildStatusPayloadAsync(userId));
+  }
 
-    return Ok(new { hasActiveSubscription });
+  private async Task<object> BuildStatusPayloadAsync(int userId)
+  {
+    var hasActiveSubscription = await _subscriptionService.HasActiveSubscriptionAsync(userId);
+    var subscription = await _subscriptionService.GetActiveSubscriptionAsync(userId);
+
+    return new
+    {
+      hasActiveSubscription,
+      subscriptionId = subscription?.Id,
+      planName = subscription?.Plan?.Name,
+      status = subscription?.Status,
+      currentPeriodEnd = subscription?.CurrentPeriodEnd,
+      cancelAtPeriodEnd = subscription?.CancelAtPeriodEnd ?? false
+    };
   }
 
   private static List<string> ParseFeatures(string featuresJson)

--- a/api/Controllers/SubscriptionController.cs
+++ b/api/Controllers/SubscriptionController.cs
@@ -167,13 +167,25 @@ public class SubscriptionController : AuthenticatedControllerBase
     {
       session = await _paymentService.GetCheckoutSessionAsync(dto.SessionId);
     }
-    catch (Stripe.StripeException ex)
+    catch (Stripe.StripeException ex) when (ex.StripeError?.Code == "resource_missing"
+        || ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
     {
       _logger.LogWarning(ex, "Checkout session {SessionId} could not be retrieved for user {UserId}", dto.SessionId, userId);
       return Problem(
         title: "Unknown checkout session",
         detail: "The checkout session could not be found.",
         statusCode: StatusCodes.Status404NotFound);
+    }
+    catch (Stripe.StripeException ex)
+    {
+      // Transient Stripe failure (5xx, rate limit, connection): the user just PAID — a
+      // "not found" here would be both wrong and alarming. 500 lets the success page fall
+      // back to polling and retry.
+      _logger.LogError(ex, "Failed to retrieve checkout session {SessionId} for user {UserId}", dto.SessionId, userId);
+      return Problem(
+        title: "Checkout verification failed",
+        detail: "Could not verify the checkout session. Please try again.",
+        statusCode: StatusCodes.Status500InternalServerError);
     }
 
     if (session.Metadata == null
@@ -210,7 +222,10 @@ public class SubscriptionController : AuthenticatedControllerBase
 
     if (subscription?.StripeCustomerId == null)
     {
-      return BadRequest(new { error = "No active subscription found" });
+      return Problem(
+        title: "No subscription",
+        detail: "There is no subscription to manage billing for.",
+        statusCode: StatusCodes.Status404NotFound);
     }
 
     try
@@ -220,8 +235,13 @@ public class SubscriptionController : AuthenticatedControllerBase
     }
     catch (Exception ex)
     {
+      // Server-side failure (Stripe outage, unconfigured Dashboard portal) — not a client
+      // error, and the 500 is what monitoring alerts on.
       _logger.LogError(ex, "Failed to create portal session for user {UserId}", userId);
-      return BadRequest(new { error = "Failed to create portal session" });
+      return Problem(
+        title: "Billing portal unavailable",
+        detail: "Could not open the billing portal. Please try again.",
+        statusCode: StatusCodes.Status500InternalServerError);
     }
   }
 

--- a/api/Migrations/20260804123939_AddCancelAtPeriodEndToUserSubscription.Designer.cs
+++ b/api/Migrations/20260804123939_AddCancelAtPeriodEndToUserSubscription.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RadioWash.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using RadioWash.Api.Infrastructure.Data;
 namespace RadioWash.Api.Migrations
 {
     [DbContext(typeof(RadioWashDbContext))]
-    partial class RadioWashDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804123939_AddCancelAtPeriodEndToUserSubscription")]
+    partial class AddCancelAtPeriodEndToUserSubscription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -266,7 +269,6 @@ namespace RadioWash.Api.Migrations
                         .HasColumnType("text");
 
                     b.Property<DateTime?>("LastAttemptAt")
-                        .IsConcurrencyToken()
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("ProcessedAt")

--- a/api/Migrations/20260804123939_AddCancelAtPeriodEndToUserSubscription.cs
+++ b/api/Migrations/20260804123939_AddCancelAtPeriodEndToUserSubscription.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RadioWash.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCancelAtPeriodEndToUserSubscription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "CancelAtPeriodEnd",
+                table: "UserSubscriptions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CancelAtPeriodEnd",
+                table: "UserSubscriptions");
+        }
+    }
+}

--- a/api/Models/DTO/SubscriptionDto.cs
+++ b/api/Models/DTO/SubscriptionDto.cs
@@ -20,13 +20,24 @@ public class UserSubscriptionDto
   public DateTime? CurrentPeriodStart { get; set; }
   public DateTime? CurrentPeriodEnd { get; set; }
   public DateTime? CanceledAt { get; set; }
+  public bool CancelAtPeriodEnd { get; set; }
   public SubscriptionPlanDto Plan { get; set; } = null!;
   public DateTime CreatedAt { get; set; }
 }
 
 public class CreateCheckoutDto
 {
-  public string PlanPriceId { get; set; } = null!;
+  // Local plan id; null selects the single active plan. The Stripe price is always
+  // resolved server-side — client-supplied price ids are never sent to Stripe.
+  public int? PlanId { get; set; }
+  // Client-generated GUID per checkout click; feeds Stripe's idempotency key so a retried
+  // request can't create duplicate checkout sessions.
+  public string? ClientRequestId { get; set; }
+}
+
+public class CompleteCheckoutDto
+{
+  public string SessionId { get; set; } = null!;
 }
 
 public class PlaylistSyncConfigDto

--- a/api/Models/Domain/UserSubscription.cs
+++ b/api/Models/Domain/UserSubscription.cs
@@ -69,6 +69,10 @@ public class UserSubscription
   public DateTime? CurrentPeriodStart { get; set; }
   public DateTime? CurrentPeriodEnd { get; set; }
   public DateTime? CanceledAt { get; set; }
+  // Mirrors Stripe's cancel_at_period_end: the user requested cancellation but keeps access
+  // until CurrentPeriodEnd; the customer.subscription.deleted webhook performs the real
+  // deactivation. Cleared automatically if the user resumes via the billing portal.
+  public bool CancelAtPeriodEnd { get; set; }
   public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
   public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -405,6 +405,26 @@ builder.Services.AddRateLimiter(options =>
             });
     });
 
+    // checkout/complete is a read-and-sync (no Stripe object creation), and the success
+    // page deliberately retries it while Stripe is having a transient outage — up to every
+    // other 2s poll tick. The 5/min "checkout" bucket would 429 that retry loop within
+    // ~20 seconds and defeat the 500-means-retry design, so it gets its own looser bucket.
+    options.AddPolicy("checkout-complete", httpContext =>
+    {
+        var userId = httpContext.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                     ?? httpContext.User?.FindFirst("sub")?.Value;
+        var partitionKey = string.IsNullOrEmpty(userId) ? "__anonymous__" : userId;
+        return System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey,
+            _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 20,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            });
+    });
+
     options.OnRejected = async (context, cancellationToken) =>
     {
         context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -113,9 +113,11 @@ builder.Services.AddScoped<IPaymentService, StripePaymentService>();
 builder.Services.AddScoped<IEventUtility, EventUtilityWrapper>();
 builder.Services.AddScoped<IStripeHealthCheckService, StripeHealthCheckService>();
 
-// Stripe services
+// Stripe services (concrete Stripe.net clients; methods are virtual, so tests mock them)
 builder.Services.AddScoped<Stripe.CustomerService>();
 builder.Services.AddScoped<Stripe.SubscriptionService>();
+builder.Services.AddScoped<Stripe.Checkout.SessionService>();
+builder.Services.AddScoped<Stripe.BillingPortal.SessionService>();
 
 // Idempotency service for webhook race condition prevention
 builder.Services.AddScoped<IIdempotencyService, DatabaseIdempotencyService>();
@@ -545,6 +547,26 @@ if (!app.Environment.IsEnvironment("Testing") && !skipMigrations)
             if (!stripeConnectivityOk)
             {
                 migrationLogger.LogWarning("Stripe connectivity test failed - check network connectivity and API keys");
+            }
+        }
+
+        // Detect drift between the configured Stripe price and the seeded plan: the seeder
+        // only runs on an empty table, so a rotated Stripe:PricePlanId leaves a stale row
+        // that silently breaks subscription-created webhooks (no matching local plan).
+        var configuredPriceId = app.Configuration["Stripe:PricePlanId"];
+        if (!string.IsNullOrEmpty(configuredPriceId))
+        {
+            var priceDbContext = scope.ServiceProvider.GetRequiredService<RadioWashDbContext>();
+            var seededPriceIds = await priceDbContext.SubscriptionPlans
+                .Where(p => p.IsActive && p.StripePriceId != null)
+                .Select(p => p.StripePriceId!)
+                .ToListAsync();
+
+            if (seededPriceIds.Count > 0 && !seededPriceIds.Contains(configuredPriceId))
+            {
+                migrationLogger.LogError(
+                    "Stripe:PricePlanId {ConfiguredPriceId} does not match any seeded SubscriptionPlan price ({SeededPriceIds}) - subscription webhooks will fail to resolve a plan",
+                    configuredPriceId, string.Join(", ", seededPriceIds));
             }
         }
     }

--- a/api/Services/Implementations/StripeHealthCheckService.cs
+++ b/api/Services/Implementations/StripeHealthCheckService.cs
@@ -6,13 +6,16 @@ namespace RadioWash.Api.Services.Implementations;
 public class StripeHealthCheckService : IStripeHealthCheckService
 {
   private readonly IConfiguration _configuration;
+  private readonly IHostEnvironment _environment;
   private readonly ILogger<StripeHealthCheckService> _logger;
 
   public StripeHealthCheckService(
       IConfiguration configuration,
+      IHostEnvironment environment,
       ILogger<StripeHealthCheckService> logger)
   {
     _configuration = configuration;
+    _environment = environment;
     _logger = logger;
   }
 
@@ -21,6 +24,7 @@ public class StripeHealthCheckService : IStripeHealthCheckService
     try
     {
       var secretKey = _configuration["Stripe:SecretKey"];
+      var publishableKey = _configuration["Stripe:PublishableKey"];
       var webhookSecret = _configuration["Stripe:WebhookSecret"];
 
       if (string.IsNullOrEmpty(secretKey))
@@ -45,6 +49,23 @@ public class StripeHealthCheckService : IStripeHealthCheckService
       {
         _logger.LogError("Stripe:WebhookSecret does not appear to be a valid Stripe webhook secret");
         return Task.FromResult(false);
+      }
+
+      // Test-mode keys in Production mean real users see checkout against a sandbox — fail
+      // startup rather than run in a silently broken mode.
+      if (_environment.IsProduction())
+      {
+        if (secretKey.StartsWith("sk_test_"))
+        {
+          _logger.LogError("Stripe:SecretKey is a test-mode key but the environment is Production");
+          return Task.FromResult(false);
+        }
+
+        if (publishableKey?.StartsWith("pk_test_") == true)
+        {
+          _logger.LogError("Stripe:PublishableKey is a test-mode key but the environment is Production");
+          return Task.FromResult(false);
+        }
       }
 
       _logger.LogInformation("Stripe configuration validation passed");

--- a/api/Services/Implementations/StripePaymentService.cs
+++ b/api/Services/Implementations/StripePaymentService.cs
@@ -12,6 +12,9 @@ public class StripePaymentService : IPaymentService
   private readonly IIdempotencyService _idempotencyService;
   private readonly IWebhookRetryService _webhookRetryService;
   private readonly IWebhookProcessor _webhookProcessor;
+  private readonly SessionService _checkoutSessionService;
+  private readonly Stripe.BillingPortal.SessionService _portalSessionService;
+  private readonly Stripe.SubscriptionService _stripeSubscriptionService;
   private readonly ILogger<StripePaymentService> _logger;
 
   public StripePaymentService(
@@ -20,6 +23,9 @@ public class StripePaymentService : IPaymentService
       IIdempotencyService idempotencyService,
       IWebhookRetryService webhookRetryService,
       IWebhookProcessor webhookProcessor,
+      SessionService checkoutSessionService,
+      Stripe.BillingPortal.SessionService portalSessionService,
+      Stripe.SubscriptionService stripeSubscriptionService,
       ILogger<StripePaymentService> logger)
   {
     _configuration = configuration;
@@ -27,12 +33,15 @@ public class StripePaymentService : IPaymentService
     _idempotencyService = idempotencyService;
     _webhookRetryService = webhookRetryService;
     _webhookProcessor = webhookProcessor;
+    _checkoutSessionService = checkoutSessionService;
+    _portalSessionService = portalSessionService;
+    _stripeSubscriptionService = stripeSubscriptionService;
     _logger = logger;
 
     StripeConfiguration.ApiKey = _configuration["Stripe:SecretKey"];
   }
 
-  public async Task<string> CreateCheckoutSessionAsync(int userId, string planPriceId)
+  public async Task<string> CreateCheckoutSessionAsync(int userId, string planPriceId, string? clientRequestId = null)
   {
     var options = new SessionCreateOptions
     {
@@ -46,7 +55,9 @@ public class StripePaymentService : IPaymentService
                 }
             },
       Mode = "subscription",
-      SuccessUrl = $"{_configuration["FrontendUrl"]}/subscription/success",
+      // {CHECKOUT_SESSION_ID} is substituted by Stripe; the success page uses it to
+      // reconcile the subscription server-side instead of racing the webhook.
+      SuccessUrl = $"{_configuration["FrontendUrl"]}/subscription/success?session_id={{CHECKOUT_SESSION_ID}}",
       CancelUrl = $"{_configuration["FrontendUrl"]}/subscription/cancel",
       Metadata = new Dictionary<string, string>
             {
@@ -61,8 +72,16 @@ public class StripePaymentService : IPaymentService
       }
     };
 
-    var service = new SessionService();
-    var session = await service.CreateAsync(options);
+    var requestOptions = string.IsNullOrEmpty(clientRequestId)
+      ? null
+      : new RequestOptions { IdempotencyKey = $"checkout-{userId}-{clientRequestId}" };
+
+    var session = await _checkoutSessionService.CreateAsync(options, requestOptions);
+
+    if (string.IsNullOrEmpty(session.Url))
+    {
+      throw new InvalidOperationException($"Stripe checkout session {session.Id} has no redirect URL");
+    }
 
     _logger.LogInformation("Created Stripe checkout session {SessionId} for user {UserId}", session.Id, userId);
 
@@ -77,10 +96,27 @@ public class StripePaymentService : IPaymentService
       ReturnUrl = $"{_configuration["FrontendUrl"]}/dashboard"
     };
 
-    var service = new Stripe.BillingPortal.SessionService();
-    var session = await service.CreateAsync(options);
+    var session = await _portalSessionService.CreateAsync(options);
 
     return session.Url;
+  }
+
+  public async Task CancelAtPeriodEndAsync(string stripeSubscriptionId)
+  {
+    await _stripeSubscriptionService.UpdateAsync(stripeSubscriptionId, new SubscriptionUpdateOptions
+    {
+      CancelAtPeriodEnd = true
+    });
+
+    _logger.LogInformation("Requested cancel-at-period-end for Stripe subscription {SubscriptionId}", stripeSubscriptionId);
+  }
+
+  public async Task<Session> GetCheckoutSessionAsync(string sessionId)
+  {
+    return await _checkoutSessionService.GetAsync(sessionId, new SessionGetOptions
+    {
+      Expand = new List<string> { "subscription" }
+    });
   }
 
   public async Task HandleWebhookAsync(string payload, string signature)

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -272,17 +272,20 @@ public class SubscriptionService : ISubscriptionService
     return await _unitOfWork.UserSubscriptions.UpdateAsync(subscription);
   }
 
-  public async Task<UserSubscription> MarkCancellationRequestedAsync(int userId)
+  public async Task<UserSubscription> MarkCancellationRequestedAsync(string stripeSubscriptionId)
   {
-    var subscription = await _unitOfWork.UserSubscriptions.GetByUserIdAsync(userId);
+    // Keyed on the Stripe subscription id so the flag lands on the exact row whose Stripe
+    // counterpart was canceled — resolving by user could pick a different (newer) row when
+    // a user has duplicate subscriptions.
+    var subscription = await _unitOfWork.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId);
     if (subscription == null)
     {
-      throw new InvalidOperationException($"No subscription found for user {userId}");
+      throw new InvalidOperationException($"No subscription found with Stripe id {stripeSubscriptionId}");
     }
 
     _logger.LogInformation(
-      "Marking subscription {SubscriptionId} for user {UserId} as cancel-at-period-end (active until {PeriodEnd})",
-      subscription.Id, userId, subscription.CurrentPeriodEnd);
+      "Marking subscription {SubscriptionId} (Stripe {StripeSubscriptionId}) as cancel-at-period-end (active until {PeriodEnd})",
+      subscription.Id, stripeSubscriptionId, subscription.CurrentPeriodEnd);
 
     // Deliberately no status change and no sync-config disabling: the user paid for the
     // rest of the period. customer.subscription.deleted performs the real deactivation.

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -97,6 +97,7 @@ public class SubscriptionService : ISubscriptionService
       StripeSubscriptionId = stripeSubscription.Id,
       StripeCustomerId = stripeSubscription.CustomerId,
       Status = status,
+      CancelAtPeriodEnd = stripeSubscription.CancelAtPeriodEnd,
       CurrentPeriodStart = periodStart,
       CurrentPeriodEnd = periodEnd,
       CanceledAt = status == SubscriptionStatus.Canceled ? DateTime.UtcNow : null,
@@ -143,6 +144,8 @@ public class SubscriptionService : ISubscriptionService
 
     existing.Status = status;
     existing.StripeCustomerId ??= stripeSubscription.CustomerId;
+    // Stripe owns this flag: a portal-side "resume" clears it here automatically.
+    existing.CancelAtPeriodEnd = stripeSubscription.CancelAtPeriodEnd;
     if (periodStart.HasValue && periodEnd.HasValue)
     {
       existing.CurrentPeriodStart = periodStart;
@@ -269,20 +272,21 @@ public class SubscriptionService : ISubscriptionService
     return await _unitOfWork.UserSubscriptions.UpdateAsync(subscription);
   }
 
-  public async Task<UserSubscription> CancelSubscriptionAsync(int userId)
+  public async Task<UserSubscription> MarkCancellationRequestedAsync(int userId)
   {
     var subscription = await _unitOfWork.UserSubscriptions.GetByUserIdAsync(userId);
     if (subscription == null)
     {
-      throw new InvalidOperationException($"No active subscription found for user {userId}");
+      throw new InvalidOperationException($"No subscription found for user {userId}");
     }
 
-    _logger.LogInformation("Canceling subscription {SubscriptionId} for user {UserId}", subscription.Id, userId);
+    _logger.LogInformation(
+      "Marking subscription {SubscriptionId} for user {UserId} as cancel-at-period-end (active until {PeriodEnd})",
+      subscription.Id, userId, subscription.CurrentPeriodEnd);
 
-    subscription.Status = SubscriptionStatus.Canceled;
-    subscription.CanceledAt = DateTime.UtcNow;
-
-    await DisableSyncConfigsForUserAsync(userId);
+    // Deliberately no status change and no sync-config disabling: the user paid for the
+    // rest of the period. customer.subscription.deleted performs the real deactivation.
+    subscription.CancelAtPeriodEnd = true;
 
     return await _unitOfWork.UserSubscriptions.UpdateAsync(subscription);
   }

--- a/api/Services/Interfaces/IPaymentService.cs
+++ b/api/Services/Interfaces/IPaymentService.cs
@@ -2,7 +2,26 @@ namespace RadioWash.Api.Services.Interfaces;
 
 public interface IPaymentService
 {
-  Task<string> CreateCheckoutSessionAsync(int userId, string planPriceId);
+  /// <summary>
+  /// Creates a Stripe Checkout session for the given (server-resolved) price. The optional
+  /// clientRequestId feeds Stripe's idempotency key so request retries can't mint duplicate
+  /// sessions.
+  /// </summary>
+  Task<string> CreateCheckoutSessionAsync(int userId, string planPriceId, string? clientRequestId = null);
+
   Task<string> CreatePortalSessionAsync(string customerId);
+
+  /// <summary>
+  /// Flags the Stripe subscription to cancel at the end of the current billing period. The
+  /// user keeps access until then; customer.subscription.deleted performs local deactivation.
+  /// </summary>
+  Task CancelAtPeriodEndAsync(string stripeSubscriptionId);
+
+  /// <summary>
+  /// Retrieves a checkout session with its subscription expanded — used by the post-redirect
+  /// reconcile endpoint so the frontend doesn't have to race the webhook.
+  /// </summary>
+  Task<Stripe.Checkout.Session> GetCheckoutSessionAsync(string sessionId);
+
   Task HandleWebhookAsync(string payload, string signature);
 }

--- a/api/Services/Interfaces/ISubscriptionService.cs
+++ b/api/Services/Interfaces/ISubscriptionService.cs
@@ -20,9 +20,10 @@ public interface ISubscriptionService
   Task<UserSubscription> SyncFromStripeAsync(Stripe.Subscription stripeSubscription, Func<Task<int?>>? resolveUserIdFallback = null);
   Task<UserSubscription> UpdateSubscriptionDatesAsync(string stripeSubscriptionId, DateTime currentPeriodStart, DateTime currentPeriodEnd);
   // Marks the local subscription cancel-at-period-end after the Stripe-side cancellation
-  // succeeded. Does NOT change status or disable sync configs — access continues until the
+  // succeeded — keyed on the same Stripe subscription id the cancel targeted. Does NOT
+  // change status or disable sync configs — access continues until the
   // customer.subscription.deleted webhook arrives at period end.
-  Task<UserSubscription> MarkCancellationRequestedAsync(int userId);
+  Task<UserSubscription> MarkCancellationRequestedAsync(string stripeSubscriptionId);
   Task<IEnumerable<SubscriptionPlan>> GetAvailablePlansAsync();
   Task<SubscriptionPlan?> GetPlanByIdAsync(int planId);
   Task<SubscriptionPlan?> GetPlanByStripePriceIdAsync(string stripePriceId);

--- a/api/Services/Interfaces/ISubscriptionService.cs
+++ b/api/Services/Interfaces/ISubscriptionService.cs
@@ -19,7 +19,10 @@ public interface ISubscriptionService
   // (e.g. a Stripe API lookup of the customer's metadata).
   Task<UserSubscription> SyncFromStripeAsync(Stripe.Subscription stripeSubscription, Func<Task<int?>>? resolveUserIdFallback = null);
   Task<UserSubscription> UpdateSubscriptionDatesAsync(string stripeSubscriptionId, DateTime currentPeriodStart, DateTime currentPeriodEnd);
-  Task<UserSubscription> CancelSubscriptionAsync(int userId);
+  // Marks the local subscription cancel-at-period-end after the Stripe-side cancellation
+  // succeeded. Does NOT change status or disable sync configs — access continues until the
+  // customer.subscription.deleted webhook arrives at period end.
+  Task<UserSubscription> MarkCancellationRequestedAsync(int userId);
   Task<IEnumerable<SubscriptionPlan>> GetAvailablePlansAsync();
   Task<SubscriptionPlan?> GetPlanByIdAsync(int planId);
   Task<SubscriptionPlan?> GetPlanByStripePriceIdAsync(string stripePriceId);

--- a/docs/stripe-runbook.md
+++ b/docs/stripe-runbook.md
@@ -12,8 +12,10 @@ redirects back to `/subscription/success?session_id=...`, where the frontend cal
 `POST /api/subscription/checkout/complete` to reconcile the subscription immediately instead of
 waiting for the webhook. Webhooks land on `POST /api/subscription/webhook`: signature failures
 return 400 (permanent reject), processing failures return 500 so Stripe redelivers for up to
-3 days; a `ProcessedWebhookEvents` claim row guarantees exactly-once processing while allowing
-failed events to be re-claimed. Subscription state is upserted from Stripe's view
+3 days; a `ProcessedWebhookEvents` claim row deduplicates deliveries while allowing failed
+events to be re-claimed. The delivery guarantee is **at-least-once** — released claims, retry
+replays, and the reconcile sweep can each re-run an event, so every handler must stay
+idempotent. Subscription state is upserted from Stripe's view
 (`SyncFromStripeAsync`), so event ordering doesn't matter. Cancellation sets
 `cancel_at_period_end` on Stripe; access continues until `customer.subscription.deleted`
 arrives. An hourly reconciliation job sweeps local state against Stripe both ways.
@@ -83,6 +85,10 @@ cancellation keep working. Remove the setting (or set `true`) to re-enable.
   page usually fixes it instantly; the hourly reconciliation job (`StripeReconciliation`)
   creates any missing rows from Stripe's active-subscription list. To force it, check the
   Stripe Dashboard for the subscription and its `userId` metadata.
+- **Duplicate active subscription** (Sentry: "already has an active subscription but Stripe
+  subscription ... arrived", or the reconciliation sweep's duplicate-entitlement error): the
+  user is being billed twice. In the Stripe Dashboard, cancel the **older** subscription and
+  refund its unused overlap; the webhook/reconciliation will sync the local rows.
 - **Disable payments entirely**: kill switch (above).
 
 ## Event → state mapping

--- a/docs/stripe-runbook.md
+++ b/docs/stripe-runbook.md
@@ -1,0 +1,98 @@
+# Stripe Payments Runbook
+
+Operational reference for the subscription/payment system. Code lives in
+`api/Services/Implementations/Stripe*`, `api/Controllers/SubscriptionController.cs`, and
+`web/src/app/subscription/`.
+
+## Architecture in one paragraph
+
+Checkout sessions are created server-side (`POST /api/subscription/checkout`) with the price
+resolved from the local `SubscriptionPlans` table — client price ids are never trusted. Stripe
+redirects back to `/subscription/success?session_id=...`, where the frontend calls
+`POST /api/subscription/checkout/complete` to reconcile the subscription immediately instead of
+waiting for the webhook. Webhooks land on `POST /api/subscription/webhook`: signature failures
+return 400 (permanent reject), processing failures return 500 so Stripe redelivers for up to
+3 days; a `ProcessedWebhookEvents` claim row guarantees exactly-once processing while allowing
+failed events to be re-claimed. Subscription state is upserted from Stripe's view
+(`SyncFromStripeAsync`), so event ordering doesn't matter. Cancellation sets
+`cancel_at_period_end` on Stripe; access continues until `customer.subscription.deleted`
+arrives. An hourly reconciliation job sweeps local state against Stripe both ways.
+
+## Production configuration
+
+All secrets are injected from GitHub Secrets into Azure App Settings by
+`.github/workflows/api-deploy.yml` — the on-disk `appsettings*.json` files are gitignored and
+must never hold live values.
+
+| Azure App Setting | GitHub Secret | Notes |
+|---|---|---|
+| `Stripe__SecretKey` | `STRIPE_SECRET_KEY` | Must be `sk_live_` in Production — startup fails on `sk_test_` |
+| `Stripe__PublishableKey` | `STRIPE_PUBLISHABLE_KEY` | Must be `pk_live_` in Production |
+| `Stripe__WebhookSecret` | `STRIPE_WEBHOOK_SECRET` | From the Dashboard webhook endpoint (below) |
+| `Stripe__PricePlanId` | `STRIPE_PRICE_PLAN_ID` | Must match the seeded `SubscriptionPlans.StripePriceId`; drift is logged as an error at startup |
+| `Features__CheckoutEnabled` | — | Kill switch, see below |
+
+## Webhook endpoint registration (manual, Dashboard)
+
+Register in the Stripe Dashboard (live mode) → Developers → Webhooks:
+
+- URL: `https://<api-host>/api/subscription/webhook`
+- Events: `checkout.session.completed`, `customer.subscription.created`,
+  `customer.subscription.updated`, `customer.subscription.deleted`,
+  `invoice.payment_succeeded`, `invoice.payment_failed`
+- Copy the signing secret into the `STRIPE_WEBHOOK_SECRET` GitHub secret and redeploy (or set
+  the Azure App Setting directly).
+
+## Customer portal (manual, Dashboard)
+
+Settings → Billing → Customer portal: enable payment-method updates, invoice history, and
+cancellation. The API's `POST /api/subscription/portal` uses the default portal configuration —
+it 400s if none is saved.
+
+## Kill switch
+
+Set Azure App Setting `Features__CheckoutEnabled = false` (App Service restarts automatically).
+New checkouts return 503 with a friendly message; existing subscriptions, webhooks, portal, and
+cancellation keep working. Remove the setting (or set `true`) to re-enable.
+
+## Launch checklist
+
+1. Rotate the live secret key and webhook signing secret (they sat on developer disks; the
+   rotation TODO in `appsettings.Production.json` tracks this). Update the GitHub secrets.
+2. Sanitize local `appsettings.json` files: base file must hold test/placeholder values only.
+3. Verify `STRIPE_PRICE_PLAN_ID` is the live $5.00/month price and matches the seeded plan row
+   (startup logs an error on drift).
+4. Register the webhook endpoint (above) and set the new signing secret.
+5. Configure the customer portal (above).
+6. Deploy, then POST a garbage-signature request to the webhook URL and confirm a Sentry event
+   arrives; create a Sentry alert rule on error-level events from the API if not already present.
+7. Kill-switch drill: set `Features__CheckoutEnabled=false`, confirm checkout 503s, revert.
+8. End-to-end smoke test with a real card: subscribe ($5) → success page activates → enable a
+   sync → cancel (verify "active until" messaging and `cancel_at_period_end` in the Dashboard)
+   → portal card update → wait for period end or delete the subscription in the Dashboard and
+   confirm sync configs auto-disable.
+
+## Incident playbook
+
+- **Webhook failures spiking** (Sentry: "Failed to process webhook event"): check DB health
+  first. Stripe redelivers on 500 for up to 3 days and the event claim is released on failure,
+  so transient outages self-heal. The internal retry queue (`WebhookRetries`) is a second net.
+- **Signature verification failures** (Sentry: "signature verification failed"): either an
+  attack (ignore) or a rotated-but-not-deployed webhook secret (fix the App Setting).
+- **User paid but not active**: `POST /api/subscription/checkout/complete` from the success
+  page usually fixes it instantly; the hourly reconciliation job (`StripeReconciliation`)
+  creates any missing rows from Stripe's active-subscription list. To force it, check the
+  Stripe Dashboard for the subscription and its `userId` metadata.
+- **Disable payments entirely**: kill switch (above).
+
+## Event → state mapping
+
+| Stripe event | Local effect |
+|---|---|
+| `customer.subscription.created` / `updated` | Upsert row (status, period dates, `CancelAtPeriodEnd`); entitled→syncs re-enabled, inactive→syncs disabled |
+| `customer.subscription.deleted` | Status `canceled`, `CanceledAt` stamped, sync configs disabled |
+| `invoice.payment_failed` | Status `past_due`, sync configs disabled |
+| `invoice.payment_succeeded` | Status `active`, previously disabled syncs re-enabled |
+| `checkout.session.completed` | Log only (subscription events carry the state) |
+
+`active` and `trialing` are the entitled statuses; `incomplete_expired` maps to `canceled`.


### PR DESCRIPTION
PR 2 of 4 in the payment production-readiness stack (parent: #66). Retarget to main after the parent squash-merges.

## Problem
Cancel only updated the local DB — the user lost access immediately, kept getting billed forever, and the next renewal webhook silently re-activated them. Checkout forwarded any client-supplied Stripe price id.

## Changes
- Cancel = `cancel_at_period_end` on Stripe first, local flag second; access continues until `customer.subscription.deleted`; portal-side resume clears the flag automatically
- Checkout: server-side plan/price resolution, 409 on double-subscribe, `Features:CheckoutEnabled` kill switch (503), client-scoped Stripe idempotency key, Problem Details everywhere, 500 (not 400) for server faults incl. portal errors
- `SuccessUrl` carries `session_id={CHECKOUT_SESSION_ID}` + new idempotent `POST /subscription/checkout/complete` reconciles from Stripe so activation doesn't race the webhook (only `resource_missing` maps to 404; transient Stripe errors are 500 so the success page retries)
- `GET /subscription/status` returns real plan name/status/renewal/cancelAtPeriodEnd (UI previously hardcoded these)
- Startup rejects test-mode keys in Production and flags Stripe price-id drift against the seeded plan
- `docs/stripe-runbook.md`: registration, rotation, portal config, kill-switch drill, launch checklist, incident playbook

## Testing
646 unit tests green at this branch (incl. Stripe-before-local cancel ordering, 409/503/session-id/idempotency-key coverage, prod key rejection). Review must-fixes addressed in the follow-up commit.
