### PR TITLE
feat(api): hourly Stripe reconciliation sweep as webhook safety net

### DIFF
--- a/api.Tests/Unit/Services/StripeReconciliationServiceTests.cs
+++ b/api.Tests/Unit/Services/StripeReconciliationServiceTests.cs
@@ -54,6 +54,20 @@ public class StripeReconciliationServiceTests
     await Task.CompletedTask;
   }
 
+  /// <summary>
+  /// Pass 2 lists each entitled status separately, so setups must match on Status — an
+  /// any-options setup would feed the same items to every listing pass.
+  /// </summary>
+  private void SetupStripeList(string status, params Stripe.Subscription[] items)
+  {
+    _mockStripeSubscriptionService
+      .Setup(x => x.ListAutoPagingAsync(
+        It.Is<SubscriptionListOptions>(o => o.Status == status),
+        It.IsAny<RequestOptions>(),
+        It.IsAny<CancellationToken>()))
+      .Returns(ToAsyncEnumerable(items));
+  }
+
   private static UserSubscription CreateLocalSubscription(string stripeId = "sub_local", int id = 1) => new()
   {
     Id = id,
@@ -149,9 +163,7 @@ public class StripeReconciliationServiceTests
     // Arrange
     var orphan = new Stripe.Subscription { Id = "sub_orphan", CustomerId = "cus_1", Status = "active" };
 
-    _mockStripeSubscriptionService
-      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
-      .Returns(ToAsyncEnumerable(new[] { orphan }));
+    SetupStripeList("active", orphan);
     _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_orphan"))
       .ReturnsAsync((UserSubscription?)null);
 
@@ -171,9 +183,7 @@ public class StripeReconciliationServiceTests
     // Arrange
     var known = new Stripe.Subscription { Id = "sub_known", Status = "active" };
 
-    _mockStripeSubscriptionService
-      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
-      .Returns(ToAsyncEnumerable(new[] { known }));
+    SetupStripeList("active", known);
     _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_known"))
       .ReturnsAsync(CreateLocalSubscription("sub_known"));
 
@@ -195,9 +205,7 @@ public class StripeReconciliationServiceTests
     var localCanceled = CreateLocalSubscription("sub_wronglycanceled");
     localCanceled.Status = SubscriptionStatus.Canceled;
 
-    _mockStripeSubscriptionService
-      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
-      .Returns(ToAsyncEnumerable(new[] { stripeActive }));
+    SetupStripeList("active", stripeActive);
     _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_wronglycanceled"))
       .ReturnsAsync(localCanceled);
 
@@ -209,6 +217,69 @@ public class StripeReconciliationServiceTests
       x => x.SyncFromStripeAsync(stripeActive, It.IsAny<Func<Task<int?>>?>()), Times.Once);
     Assert.Equal(1, result.LocalUpdated);
     Assert.Equal(0, result.MissingCreated);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WithTrialingStripeSubscriptionMissingLocally_ShouldCreateFromStripe()
+  {
+    // Arrange - trialing is entitled everywhere else in the app (HasActiveSubscription,
+    // status mapper), so the sweep must also recover trialing subscriptions whose webhooks
+    // were lost, not just active ones.
+    var trialOrphan = new Stripe.Subscription { Id = "sub_trial", CustomerId = "cus_t", Status = "trialing" };
+
+    SetupStripeList("trialing", trialOrphan);
+    _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_trial"))
+      .ReturnsAsync((UserSubscription?)null);
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(trialOrphan, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+    Assert.Equal(1, result.MissingCreated);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WhenStripeTrialingButLocalCanceled_ShouldHealFromStripe()
+  {
+    // Arrange - a wrongly-canceled trialing subscription: pass 1 skips canceled rows, so
+    // only the trialing listing pass can heal it.
+    var stripeTrialing = new Stripe.Subscription { Id = "sub_trial_healed", CustomerId = "cus_t", Status = "trialing" };
+    var localCanceled = CreateLocalSubscription("sub_trial_healed");
+    localCanceled.Status = SubscriptionStatus.Canceled;
+
+    SetupStripeList("trialing", stripeTrialing);
+    _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_trial_healed"))
+      .ReturnsAsync(localCanceled);
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(stripeTrialing, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+    Assert.Equal(1, result.LocalUpdated);
+    Assert.Equal(0, result.MissingCreated);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_ListsExactlyTheEntitledStatuses()
+  {
+    // Pins pass 2's Stripe listing filters: one pass per entitled status, nothing else.
+    // If this fails after an entitlement change, update EntitledStripeStatuses in the
+    // service to match SubscriptionStatusMapper.IsEntitled.
+    await _service.ReconcileAsync();
+
+    _mockStripeSubscriptionService.Verify(x => x.ListAutoPagingAsync(
+      It.Is<SubscriptionListOptions>(o => o.Status == "active"),
+      It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+    _mockStripeSubscriptionService.Verify(x => x.ListAutoPagingAsync(
+      It.Is<SubscriptionListOptions>(o => o.Status == "trialing"),
+      It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+    _mockStripeSubscriptionService.Verify(x => x.ListAutoPagingAsync(
+      It.IsAny<SubscriptionListOptions>(),
+      It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
   }
 
   [Fact]
@@ -256,9 +327,7 @@ public class StripeReconciliationServiceTests
     var badOrphan = new Stripe.Subscription { Id = "sub_bad", CustomerId = "cus_bad", Status = "active" };
     var goodOrphan = new Stripe.Subscription { Id = "sub_good", CustomerId = "cus_good", Status = "active" };
 
-    _mockStripeSubscriptionService
-      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
-      .Returns(ToAsyncEnumerable(new[] { badOrphan, goodOrphan }));
+    SetupStripeList("active", badOrphan, goodOrphan);
     _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync(It.IsAny<string>()))
       .ReturnsAsync((UserSubscription?)null);
     _mockSubscriptionService
@@ -283,9 +352,7 @@ public class StripeReconciliationServiceTests
     var orphan = new Stripe.Subscription { Id = "sub_orphan", CustomerId = "cus_42", Status = "active" };
     Func<Task<int?>>? capturedFallback = null;
 
-    _mockStripeSubscriptionService
-      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
-      .Returns(ToAsyncEnumerable(new[] { orphan }));
+    SetupStripeList("active", orphan);
     _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_orphan"))
       .ReturnsAsync((UserSubscription?)null);
     _mockSubscriptionService

--- a/api.Tests/Unit/Services/StripeReconciliationServiceTests.cs
+++ b/api.Tests/Unit/Services/StripeReconciliationServiceTests.cs
@@ -1,0 +1,243 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RadioWash.Api.Models.Domain;
+using RadioWash.Api.Services.Implementations;
+using RadioWash.Api.Services.Interfaces;
+using Stripe;
+using Xunit;
+
+namespace RadioWash.Api.Tests.Unit.Services;
+
+public class StripeReconciliationServiceTests
+{
+  private readonly Mock<ISubscriptionService> _mockSubscriptionService;
+  private readonly Mock<Stripe.SubscriptionService> _mockStripeSubscriptionService;
+  private readonly Mock<CustomerService> _mockCustomerService;
+  private readonly StripeReconciliationService _service;
+
+  public StripeReconciliationServiceTests()
+  {
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        ["Stripe:SecretKey"] = "sk_test_123"
+      })
+      .Build();
+
+    _mockSubscriptionService = new Mock<ISubscriptionService>();
+    _mockStripeSubscriptionService = new Mock<Stripe.SubscriptionService>();
+    _mockCustomerService = new Mock<CustomerService>();
+
+    // Default: nothing local to reconcile, nothing active on Stripe.
+    _mockSubscriptionService.Setup(x => x.GetReconcilableSubscriptionsAsync())
+      .ReturnsAsync(new List<UserSubscription>());
+    _mockStripeSubscriptionService
+      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .Returns(ToAsyncEnumerable(new List<Stripe.Subscription>()));
+
+    _service = new StripeReconciliationService(
+      configuration,
+      _mockSubscriptionService.Object,
+      _mockStripeSubscriptionService.Object,
+      _mockCustomerService.Object,
+      Mock.Of<ILogger<StripeReconciliationService>>());
+  }
+
+  private static async IAsyncEnumerable<Stripe.Subscription> ToAsyncEnumerable(IEnumerable<Stripe.Subscription> items)
+  {
+    foreach (var item in items)
+    {
+      yield return item;
+    }
+
+    await Task.CompletedTask;
+  }
+
+  private static UserSubscription CreateLocalSubscription(string stripeId = "sub_local", int id = 1) => new()
+  {
+    Id = id,
+    UserId = 1,
+    PlanId = 1,
+    StripeSubscriptionId = stripeId,
+    Status = SubscriptionStatus.Active
+  };
+
+  [Fact]
+  public async Task ReconcileAsync_WithLocalSubscription_ShouldSyncFromStripe()
+  {
+    // Arrange
+    var local = CreateLocalSubscription();
+    var stripeSubscription = new Stripe.Subscription { Id = "sub_local", Status = "active" };
+
+    _mockSubscriptionService.Setup(x => x.GetReconcilableSubscriptionsAsync())
+      .ReturnsAsync(new List<UserSubscription> { local });
+    _mockStripeSubscriptionService
+      .Setup(x => x.GetAsync("sub_local", It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(stripeSubscription);
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(stripeSubscription, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+    Assert.Equal(1, result.LocalChecked);
+    Assert.Equal(1, result.LocalUpdated);
+    Assert.Equal(0, result.Errors);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WhenSubscriptionMissingOnStripe_ShouldCancelLocally()
+  {
+    // Arrange
+    var local = CreateLocalSubscription();
+    var missingException = new StripeException("No such subscription")
+    {
+      StripeError = new StripeError { Code = "resource_missing" }
+    };
+
+    _mockSubscriptionService.Setup(x => x.GetReconcilableSubscriptionsAsync())
+      .ReturnsAsync(new List<UserSubscription> { local });
+    _mockStripeSubscriptionService
+      .Setup(x => x.GetAsync("sub_local", It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(missingException);
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.UpdateSubscriptionStatusAsync("sub_local", SubscriptionStatus.Canceled), Times.Once);
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()), Times.Never);
+    Assert.Equal(1, result.LocalUpdated);
+    Assert.Equal(0, result.Errors);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WhenOneLocalSubscriptionFails_ShouldContinueWithOthers()
+  {
+    // Arrange
+    var failing = CreateLocalSubscription("sub_fail", 1);
+    var healthy = CreateLocalSubscription("sub_ok", 2);
+
+    _mockSubscriptionService.Setup(x => x.GetReconcilableSubscriptionsAsync())
+      .ReturnsAsync(new List<UserSubscription> { failing, healthy });
+    _mockStripeSubscriptionService
+      .Setup(x => x.GetAsync("sub_fail", It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new HttpRequestException("network down"));
+    _mockStripeSubscriptionService
+      .Setup(x => x.GetAsync("sub_ok", It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new Stripe.Subscription { Id = "sub_ok", Status = "active" });
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(It.Is<Stripe.Subscription>(s => s.Id == "sub_ok"), It.IsAny<Func<Task<int?>>?>()),
+      Times.Once);
+    Assert.Equal(2, result.LocalChecked);
+    Assert.Equal(1, result.LocalUpdated);
+    Assert.Equal(1, result.Errors);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WithActiveStripeSubscriptionMissingLocally_ShouldCreateFromStripe()
+  {
+    // Arrange
+    var orphan = new Stripe.Subscription { Id = "sub_orphan", CustomerId = "cus_1", Status = "active" };
+
+    _mockStripeSubscriptionService
+      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .Returns(ToAsyncEnumerable(new[] { orphan }));
+    _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_orphan"))
+      .ReturnsAsync((UserSubscription?)null);
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(orphan, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+    Assert.Equal(1, result.MissingCreated);
+    Assert.Equal(0, result.Errors);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WithActiveStripeSubscriptionKnownLocally_ShouldNotCreate()
+  {
+    // Arrange
+    var known = new Stripe.Subscription { Id = "sub_known", Status = "active" };
+
+    _mockStripeSubscriptionService
+      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .Returns(ToAsyncEnumerable(new[] { known }));
+    _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_known"))
+      .ReturnsAsync(CreateLocalSubscription("sub_known"));
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(It.IsAny<Stripe.Subscription>(), It.IsAny<Func<Task<int?>>?>()), Times.Never);
+    Assert.Equal(0, result.MissingCreated);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WhenOrphanSyncFails_ShouldCountErrorAndContinue()
+  {
+    // Arrange - two orphans; the first cannot resolve a user, the second succeeds.
+    var badOrphan = new Stripe.Subscription { Id = "sub_bad", CustomerId = "cus_bad", Status = "active" };
+    var goodOrphan = new Stripe.Subscription { Id = "sub_good", CustomerId = "cus_good", Status = "active" };
+
+    _mockStripeSubscriptionService
+      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .Returns(ToAsyncEnumerable(new[] { badOrphan, goodOrphan }));
+    _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync(It.IsAny<string>()))
+      .ReturnsAsync((UserSubscription?)null);
+    _mockSubscriptionService
+      .Setup(x => x.SyncFromStripeAsync(badOrphan, It.IsAny<Func<Task<int?>>?>()))
+      .ThrowsAsync(new InvalidOperationException("Could not determine user"));
+    _mockSubscriptionService
+      .Setup(x => x.SyncFromStripeAsync(goodOrphan, It.IsAny<Func<Task<int?>>?>()))
+      .ReturnsAsync(CreateLocalSubscription("sub_good"));
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    Assert.Equal(1, result.MissingCreated);
+    Assert.Equal(1, result.Errors);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_OrphanUserIdFallback_ShouldReadCustomerMetadata()
+  {
+    // Arrange
+    var orphan = new Stripe.Subscription { Id = "sub_orphan", CustomerId = "cus_42", Status = "active" };
+    Func<Task<int?>>? capturedFallback = null;
+
+    _mockStripeSubscriptionService
+      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .Returns(ToAsyncEnumerable(new[] { orphan }));
+    _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_orphan"))
+      .ReturnsAsync((UserSubscription?)null);
+    _mockSubscriptionService
+      .Setup(x => x.SyncFromStripeAsync(orphan, It.IsAny<Func<Task<int?>>?>()))
+      .Callback<Stripe.Subscription, Func<Task<int?>>?>((_, fallback) => capturedFallback = fallback)
+      .ReturnsAsync(CreateLocalSubscription("sub_orphan"));
+    _mockCustomerService
+      .Setup(x => x.GetAsync("cus_42", It.IsAny<CustomerGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new Customer { Id = "cus_42", Metadata = new Dictionary<string, string> { ["userId"] = "42" } });
+
+    // Act
+    await _service.ReconcileAsync();
+
+    // Assert
+    Assert.NotNull(capturedFallback);
+    Assert.Equal(42, await capturedFallback!());
+  }
+}

--- a/api.Tests/Unit/Services/StripeReconciliationServiceTests.cs
+++ b/api.Tests/Unit/Services/StripeReconciliationServiceTests.cs
@@ -187,6 +187,69 @@ public class StripeReconciliationServiceTests
   }
 
   [Fact]
+  public async Task ReconcileAsync_WhenStripeActiveButLocalCanceled_ShouldHealFromStripe()
+  {
+    // Arrange - a wrongly-canceled local row (e.g. expiry sweep fired during a Stripe
+    // outage) must heal: pass 1 skips canceled rows, so pass 2 owns this case.
+    var stripeActive = new Stripe.Subscription { Id = "sub_wronglycanceled", CustomerId = "cus_1", Status = "active" };
+    var localCanceled = CreateLocalSubscription("sub_wronglycanceled");
+    localCanceled.Status = SubscriptionStatus.Canceled;
+
+    _mockStripeSubscriptionService
+      .Setup(x => x.ListAutoPagingAsync(It.IsAny<SubscriptionListOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .Returns(ToAsyncEnumerable(new[] { stripeActive }));
+    _mockSubscriptionService.Setup(x => x.GetByStripeSubscriptionIdAsync("sub_wronglycanceled"))
+      .ReturnsAsync(localCanceled);
+
+    // Act
+    var result = await _service.ReconcileAsync();
+
+    // Assert
+    _mockSubscriptionService.Verify(
+      x => x.SyncFromStripeAsync(stripeActive, It.IsAny<Func<Task<int?>>?>()), Times.Once);
+    Assert.Equal(1, result.LocalUpdated);
+    Assert.Equal(0, result.MissingCreated);
+  }
+
+  [Fact]
+  public async Task ReconcileAsync_WithDuplicateEntitledSubscriptions_ShouldLogErrorEverySweep()
+  {
+    // Arrange - two entitled rows for the same user = double billing; must be flagged as an
+    // error on every sweep until resolved
+    var first = CreateLocalSubscription("sub_a", 1);
+    var second = CreateLocalSubscription("sub_b", 2);
+
+    _mockSubscriptionService.Setup(x => x.GetReconcilableSubscriptionsAsync())
+      .ReturnsAsync(new List<UserSubscription> { first, second });
+    _mockStripeSubscriptionService
+      .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<SubscriptionGetOptions>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync((string id, SubscriptionGetOptions _, RequestOptions _, CancellationToken _) =>
+        new Stripe.Subscription { Id = id, Status = "active" });
+
+    var mockLogger = new Mock<ILogger<StripeReconciliationService>>();
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?> { ["Stripe:SecretKey"] = "sk_test_123" })
+      .Build();
+    var service = new StripeReconciliationService(
+      configuration,
+      _mockSubscriptionService.Object,
+      _mockStripeSubscriptionService.Object,
+      _mockCustomerService.Object,
+      mockLogger.Object);
+
+    // Act
+    await service.ReconcileAsync();
+
+    // Assert - an error-level log (reaches Sentry) mentioning both subscriptions
+    mockLogger.Verify(l => l.Log(
+      LogLevel.Error,
+      It.IsAny<EventId>(),
+      It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("sub_a") && state.ToString()!.Contains("sub_b")),
+      It.IsAny<Exception?>(),
+      It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+  }
+
+  [Fact]
   public async Task ReconcileAsync_WhenOrphanSyncFails_ShouldCountErrorAndContinue()
   {
     // Arrange - two orphans; the first cannot resolve a user, the second succeeds.

--- a/api/Infrastructure/Repositories/IUserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/IUserSubscriptionRepository.cs
@@ -14,6 +14,9 @@ public interface IUserSubscriptionRepository
   Task<IEnumerable<UserSubscription>> GetExpiringSubscriptionsAsync(DateTime before);
   Task<IEnumerable<UserSubscription>> GetExpiringSubscriptionsWithDetailsAsync(DateTime before);
   Task<IEnumerable<UserSubscription>> GetExpiredActiveSubscriptionsAsync(DateTime cutoff);
+  // Subscriptions worth re-checking against Stripe: everything with a Stripe id that isn't
+  // terminally canceled. Used by the reconciliation sweep.
+  Task<IEnumerable<UserSubscription>> GetReconcilableSubscriptionsAsync();
   Task<UserSubscription> CreateAsync(UserSubscription subscription);
   // Returns null when a concurrent writer already created a row for the same
   // StripeSubscriptionId (unique filtered index); the failed insert is detached so the

--- a/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
+++ b/api/Infrastructure/Repositories/UserSubscriptionRepository.cs
@@ -104,6 +104,14 @@ public class UserSubscriptionRepository : IUserSubscriptionRepository
         .ToListAsync();
   }
 
+  public async Task<IEnumerable<UserSubscription>> GetReconcilableSubscriptionsAsync()
+  {
+    return await _dbContext.UserSubscriptions
+        .Where(us => us.StripeSubscriptionId != null &&
+                    us.Status != SubscriptionStatus.Canceled)
+        .ToListAsync();
+  }
+
   public async Task<UserSubscription> CreateAsync(UserSubscription subscription)
   {
     _dbContext.UserSubscriptions.Add(subscription);

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -381,6 +381,8 @@ if (!builder.Environment.IsEnvironment("Testing") && !builder.Environment.IsEnvi
 builder.Services.AddHostedService<WebhookRetryBackgroundService>();
 builder.Services.AddHostedService<SubscriptionExpiryBackgroundService>();
 builder.Services.AddHostedService<WebhookTableRetentionBackgroundService>();
+builder.Services.AddScoped<IStripeReconciliationService, StripeReconciliationService>();
+builder.Services.AddHostedService<StripeReconciliationBackgroundService>();
 
 // Rate limiting: per-authenticated-user bucket for subscription checkout/portal endpoints.
 // The Stripe webhook endpoint is deliberately NOT rate-limited — Stripe retries aggressively

--- a/api/Services/BackgroundServices/StripeReconciliationBackgroundService.cs
+++ b/api/Services/BackgroundServices/StripeReconciliationBackgroundService.cs
@@ -15,8 +15,19 @@ public class StripeReconciliationBackgroundService : BackgroundService
     {
         _serviceProvider = serviceProvider;
         _logger = logger;
-        _processingInterval = TimeSpan.FromMinutes(
-            configuration.GetValue("Stripe:ReconciliationIntervalMinutes", 60));
+
+        // Clamp: a negative value would make Task.Delay throw (unhandled exceptions in a
+        // BackgroundService stop the HOST since .NET 6), and 0 would turn the loop into a
+        // hot loop hammering Stripe's rate-limited API.
+        var intervalMinutes = configuration.GetValue("Stripe:ReconciliationIntervalMinutes", 60);
+        if (intervalMinutes < 1)
+        {
+            _logger.LogWarning(
+                "Stripe:ReconciliationIntervalMinutes value {Configured} is invalid; falling back to 60 minutes",
+                intervalMinutes);
+            intervalMinutes = 60;
+        }
+        _processingInterval = TimeSpan.FromMinutes(intervalMinutes);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/api/Services/BackgroundServices/StripeReconciliationBackgroundService.cs
+++ b/api/Services/BackgroundServices/StripeReconciliationBackgroundService.cs
@@ -1,0 +1,62 @@
+using RadioWash.Api.Services.Interfaces;
+
+namespace RadioWash.Api.Services.BackgroundServices;
+
+public class StripeReconciliationBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<StripeReconciliationBackgroundService> _logger;
+    private readonly TimeSpan _processingInterval;
+
+    public StripeReconciliationBackgroundService(
+        IServiceProvider serviceProvider,
+        IConfiguration configuration,
+        ILogger<StripeReconciliationBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _processingInterval = TimeSpan.FromMinutes(
+            configuration.GetValue("Stripe:ReconciliationIntervalMinutes", 60));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("StripeReconciliationBackgroundService started (interval {Interval})", _processingInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Interval first: at boot, webhooks are healthier signals than a reconcile
+            // sweep, and this avoids hammering Stripe on crash-restart loops.
+            try
+            {
+                await Task.Delay(_processingInterval, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+
+            try
+            {
+                await ReconcileOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during Stripe reconciliation: {ErrorMessage}", ex.Message);
+            }
+        }
+
+        _logger.LogInformation("StripeReconciliationBackgroundService stopped");
+    }
+
+    private async Task ReconcileOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var reconciliationService = scope.ServiceProvider.GetRequiredService<IStripeReconciliationService>();
+        await reconciliationService.ReconcileAsync(cancellationToken);
+    }
+}

--- a/api/Services/Implementations/StripeReconciliationService.cs
+++ b/api/Services/Implementations/StripeReconciliationService.cs
@@ -46,7 +46,20 @@ public class StripeReconciliationService : IStripeReconciliationService
   // lost status/date/cancel-flag webhook heals within one interval.
   private async Task ReconcileLocalSubscriptionsAsync(StripeReconciliationResult result, CancellationToken cancellationToken)
   {
-    var localSubscriptions = await _subscriptionService.GetReconcilableSubscriptionsAsync();
+    var localSubscriptions = (await _subscriptionService.GetReconcilableSubscriptionsAsync()).ToList();
+
+    // A user with more than one entitled subscription is being double-billed. Logged as an
+    // error on EVERY sweep (not just at creation time) so the alert repeats until a human
+    // resolves it — see the runbook's duplicate-active-subscription entry.
+    foreach (var duplicates in localSubscriptions
+      .Where(s => SubscriptionStatusMapper.IsEntitled(s.Status))
+      .GroupBy(s => s.UserId)
+      .Where(g => g.Count() > 1))
+    {
+      _logger.LogError(
+        "User {UserId} has {Count} entitled subscriptions ({SubscriptionIds}) — double billing; cancel the older one in the Stripe Dashboard",
+        duplicates.Key, duplicates.Count(), string.Join(", ", duplicates.Select(s => s.StripeSubscriptionId)));
+    }
 
     foreach (var local in localSubscriptions)
     {
@@ -110,6 +123,21 @@ public class StripeReconciliationService : IStripeReconciliationService
         var local = await _subscriptionService.GetByStripeSubscriptionIdAsync(stripeSubscription.Id);
         if (local != null)
         {
+          // Stripe says active but the local row is not entitled — e.g. the expiry sweep
+          // canceled a paying user while Stripe was unreachable. Pass 1 skips canceled rows,
+          // so without this branch a wrongly-canceled subscription would never heal.
+          if (!SubscriptionStatusMapper.IsEntitled(local.Status))
+          {
+            _logger.LogWarning(
+              "Stripe subscription {StripeSubscriptionId} is active but local status is {LocalStatus}; healing from Stripe state",
+              stripeSubscription.Id, local.Status);
+
+            await _subscriptionService.SyncFromStripeAsync(
+              stripeSubscription,
+              () => ResolveUserIdFromCustomerAsync(stripeSubscription.CustomerId));
+            result.LocalUpdated++;
+          }
+
           continue;
         }
 

--- a/api/Services/Implementations/StripeReconciliationService.cs
+++ b/api/Services/Implementations/StripeReconciliationService.cs
@@ -1,0 +1,147 @@
+using RadioWash.Api.Models.Domain;
+using RadioWash.Api.Services.Interfaces;
+using Stripe;
+
+namespace RadioWash.Api.Services.Implementations;
+
+public class StripeReconciliationService : IStripeReconciliationService
+{
+  private readonly IConfiguration _configuration;
+  private readonly ISubscriptionService _subscriptionService;
+  private readonly Stripe.SubscriptionService _stripeSubscriptionService;
+  private readonly CustomerService _customerService;
+  private readonly ILogger<StripeReconciliationService> _logger;
+
+  public StripeReconciliationService(
+      IConfiguration configuration,
+      ISubscriptionService subscriptionService,
+      Stripe.SubscriptionService stripeSubscriptionService,
+      CustomerService customerService,
+      ILogger<StripeReconciliationService> logger)
+  {
+    _configuration = configuration;
+    _subscriptionService = subscriptionService;
+    _stripeSubscriptionService = stripeSubscriptionService;
+    _customerService = customerService;
+    _logger = logger;
+
+    StripeConfiguration.ApiKey = _configuration["Stripe:SecretKey"];
+  }
+
+  public async Task<StripeReconciliationResult> ReconcileAsync(CancellationToken cancellationToken = default)
+  {
+    var result = new StripeReconciliationResult();
+
+    await ReconcileLocalSubscriptionsAsync(result, cancellationToken);
+    await ReconcileMissingLocalRowsAsync(result, cancellationToken);
+
+    _logger.LogInformation(
+      "Stripe reconciliation finished: {LocalChecked} local checked, {LocalUpdated} updated, {MissingCreated} missing rows created, {Errors} errors",
+      result.LocalChecked, result.LocalUpdated, result.MissingCreated, result.Errors);
+
+    return result;
+  }
+
+  // Pass 1: every non-terminal local subscription is re-read from Stripe and upserted, so a
+  // lost status/date/cancel-flag webhook heals within one interval.
+  private async Task ReconcileLocalSubscriptionsAsync(StripeReconciliationResult result, CancellationToken cancellationToken)
+  {
+    var localSubscriptions = await _subscriptionService.GetReconcilableSubscriptionsAsync();
+
+    foreach (var local in localSubscriptions)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      if (string.IsNullOrEmpty(local.StripeSubscriptionId))
+      {
+        continue;
+      }
+
+      result.LocalChecked++;
+
+      try
+      {
+        var stripeSubscription = await _stripeSubscriptionService.GetAsync(
+          local.StripeSubscriptionId, cancellationToken: cancellationToken);
+
+        await _subscriptionService.SyncFromStripeAsync(stripeSubscription);
+        result.LocalUpdated++;
+      }
+      catch (StripeException ex) when (ex.StripeError?.Code == "resource_missing")
+      {
+        // Stripe no longer knows this subscription — the deletion webhook was lost.
+        _logger.LogWarning(
+          "Local subscription {SubscriptionId} (Stripe {StripeSubscriptionId}) no longer exists on Stripe; canceling locally",
+          local.Id, local.StripeSubscriptionId);
+
+        try
+        {
+          await _subscriptionService.UpdateSubscriptionStatusAsync(local.StripeSubscriptionId, SubscriptionStatus.Canceled);
+          result.LocalUpdated++;
+        }
+        catch (Exception cancelEx)
+        {
+          result.Errors++;
+          _logger.LogError(cancelEx, "Failed to cancel orphaned local subscription {SubscriptionId}", local.Id);
+        }
+      }
+      catch (Exception ex)
+      {
+        result.Errors++;
+        _logger.LogError(ex, "Failed to reconcile local subscription {SubscriptionId} (Stripe {StripeSubscriptionId})",
+          local.Id, local.StripeSubscriptionId);
+      }
+    }
+  }
+
+  // Pass 2: every active subscription on Stripe must have a local row. This is the recovery
+  // path for "user charged, all webhooks lost". (Stripe's list filter is a single status;
+  // active covers the paid case that matters — trialing rows are created by pass 1 or the
+  // next webhook.)
+  private async Task ReconcileMissingLocalRowsAsync(StripeReconciliationResult result, CancellationToken cancellationToken)
+  {
+    var options = new SubscriptionListOptions { Status = "active", Limit = 100 };
+
+    await foreach (var stripeSubscription in _stripeSubscriptionService
+      .ListAutoPagingAsync(options, cancellationToken: cancellationToken))
+    {
+      try
+      {
+        var local = await _subscriptionService.GetByStripeSubscriptionIdAsync(stripeSubscription.Id);
+        if (local != null)
+        {
+          continue;
+        }
+
+        _logger.LogWarning(
+          "Stripe subscription {StripeSubscriptionId} is active but has no local record; creating from Stripe state",
+          stripeSubscription.Id);
+
+        await _subscriptionService.SyncFromStripeAsync(
+          stripeSubscription,
+          () => ResolveUserIdFromCustomerAsync(stripeSubscription.CustomerId));
+
+        result.MissingCreated++;
+      }
+      catch (Exception ex)
+      {
+        result.Errors++;
+        _logger.LogError(ex,
+          "Failed to reconcile Stripe subscription {StripeSubscriptionId} with no local record",
+          stripeSubscription.Id);
+      }
+    }
+  }
+
+  private async Task<int?> ResolveUserIdFromCustomerAsync(string customerId)
+  {
+    var customer = await _customerService.GetAsync(customerId);
+    if (customer?.Metadata?.TryGetValue("userId", out var userIdStr) == true
+        && int.TryParse(userIdStr, out var userId))
+    {
+      return userId;
+    }
+
+    return null;
+  }
+}

--- a/api/Services/Implementations/StripeReconciliationService.cs
+++ b/api/Services/Implementations/StripeReconciliationService.cs
@@ -107,13 +107,26 @@ public class StripeReconciliationService : IStripeReconciliationService
     }
   }
 
-  // Pass 2: every active subscription on Stripe must have a local row. This is the recovery
-  // path for "user charged, all webhooks lost". (Stripe's list filter is a single status;
-  // active covers the paid case that matters — trialing rows are created by pass 1 or the
-  // next webhook.)
+  // Pass 2: every entitled subscription on Stripe must have a matching local row. This is
+  // the recovery path for "user charged, all webhooks lost". Stripe's list filter takes a
+  // single status, so each entitled status gets its own listing pass — the set here must
+  // stay in lockstep with SubscriptionStatusMapper.IsEntitled, or subscriptions in the
+  // missing status become invisible to the sweep (unhealable wrongful cancellations,
+  // uncreatable missing rows).
+  private static readonly string[] EntitledStripeStatuses = { "active", "trialing" };
+
   private async Task ReconcileMissingLocalRowsAsync(StripeReconciliationResult result, CancellationToken cancellationToken)
   {
-    var options = new SubscriptionListOptions { Status = "active", Limit = 100 };
+    foreach (var entitledStatus in EntitledStripeStatuses)
+    {
+      await ReconcileMissingLocalRowsForStatusAsync(entitledStatus, result, cancellationToken);
+    }
+  }
+
+  private async Task ReconcileMissingLocalRowsForStatusAsync(
+      string stripeStatus, StripeReconciliationResult result, CancellationToken cancellationToken)
+  {
+    var options = new SubscriptionListOptions { Status = stripeStatus, Limit = 100 };
 
     await foreach (var stripeSubscription in _stripeSubscriptionService
       .ListAutoPagingAsync(options, cancellationToken: cancellationToken))
@@ -129,8 +142,8 @@ public class StripeReconciliationService : IStripeReconciliationService
           if (!SubscriptionStatusMapper.IsEntitled(local.Status))
           {
             _logger.LogWarning(
-              "Stripe subscription {StripeSubscriptionId} is active but local status is {LocalStatus}; healing from Stripe state",
-              stripeSubscription.Id, local.Status);
+              "Stripe subscription {StripeSubscriptionId} is {StripeStatus} but local status is {LocalStatus}; healing from Stripe state",
+              stripeSubscription.Id, stripeStatus, local.Status);
 
             await _subscriptionService.SyncFromStripeAsync(
               stripeSubscription,
@@ -142,8 +155,8 @@ public class StripeReconciliationService : IStripeReconciliationService
         }
 
         _logger.LogWarning(
-          "Stripe subscription {StripeSubscriptionId} is active but has no local record; creating from Stripe state",
-          stripeSubscription.Id);
+          "Stripe subscription {StripeSubscriptionId} is {StripeStatus} but has no local record; creating from Stripe state",
+          stripeSubscription.Id, stripeStatus);
 
         await _subscriptionService.SyncFromStripeAsync(
           stripeSubscription,

--- a/api/Services/Implementations/SubscriptionService.cs
+++ b/api/Services/Implementations/SubscriptionService.cs
@@ -37,6 +37,11 @@ public class SubscriptionService : ISubscriptionService
     return await _unitOfWork.UserSubscriptions.GetByStripeSubscriptionIdAsync(stripeSubscriptionId);
   }
 
+  public async Task<IEnumerable<UserSubscription>> GetReconcilableSubscriptionsAsync()
+  {
+    return await _unitOfWork.UserSubscriptions.GetReconcilableSubscriptionsAsync();
+  }
+
   public async Task<UserSubscription> SyncFromStripeAsync(
       Stripe.Subscription stripeSubscription,
       Func<Task<int?>>? resolveUserIdFallback = null)

--- a/api/Services/Interfaces/IStripeReconciliationService.cs
+++ b/api/Services/Interfaces/IStripeReconciliationService.cs
@@ -1,0 +1,19 @@
+namespace RadioWash.Api.Services.Interfaces;
+
+public class StripeReconciliationResult
+{
+  public int LocalChecked { get; set; }
+  public int LocalUpdated { get; set; }
+  public int MissingCreated { get; set; }
+  public int Errors { get; set; }
+}
+
+/// <summary>
+/// Safety net for webhook loss: periodically reconciles local subscription state against
+/// Stripe in both directions. Catches the "user charged on Stripe but no local row" case
+/// (all webhooks lost) and local rows that drifted from Stripe's status.
+/// </summary>
+public interface IStripeReconciliationService
+{
+  Task<StripeReconciliationResult> ReconcileAsync(CancellationToken cancellationToken = default);
+}

--- a/api/Services/Interfaces/ISubscriptionService.cs
+++ b/api/Services/Interfaces/ISubscriptionService.cs
@@ -7,6 +7,8 @@ public interface ISubscriptionService
   Task<UserSubscription?> GetActiveSubscriptionAsync(int userId);
   Task<bool> HasActiveSubscriptionAsync(int userId);
   Task<UserSubscription?> GetByStripeSubscriptionIdAsync(string stripeSubscriptionId);
+  // Non-terminal subscriptions with a Stripe id, for the reconciliation sweep.
+  Task<IEnumerable<UserSubscription>> GetReconcilableSubscriptionsAsync();
   Task<UserSubscription> CreateSubscriptionAsync(int userId, int planId, string stripeSubscriptionId, string stripeCustomerId);
   Task<UserSubscription> UpdateSubscriptionStatusAsync(string stripeSubscriptionId, string status);
   // Creates or updates the local subscription row from Stripe's current view of the


### PR DESCRIPTION
PR 3 of 4 in the payment production-readiness stack (parent: #67). Retarget after the parent squash-merges.

## Problem
Even with 500-triggered redelivery and the internal retry queue, webhook delivery can ultimately fail (3-day window expiring, misconfigured endpoint). Nothing ever compared local subscription state against Stripe — worst case: a user charged on Stripe with no local subscription, forever.

## Changes
- `StripeReconciliationService` runs hourly (configurable), two fault-isolated passes:
  - Pass 1: every non-terminal local subscription re-read from Stripe and upserted; `resource_missing` → canceled locally
  - Pass 2: every active Stripe subscription must have a local row (creates missing ones from Stripe state) **and** heals wrongly-canceled local rows that Stripe contradicts — e.g. the expiry sweep firing during a Stripe outage no longer locks out a paying user permanently
- Users with >1 entitled subscription are logged as an error on every sweep (repeating Sentry alert) until resolved — double-billing can't hide in a single missed log line
- Summary line per sweep (checked/updated/created/errors)

## Testing
658 unit tests green at this branch (drift both directions, resource_missing, per-item fault isolation, wrongful-cancellation healing, duplicate-entitlement alert).
