### PR TITLE
fix(web): reliable checkout UX — typed errors, success-page reconcile, portal access

### DIFF
--- a/web/src/app/dashboard/sync/sync-dashboard-client.tsx
+++ b/web/src/app/dashboard/sync/sync-dashboard-client.tsx
@@ -9,13 +9,14 @@ import {
   useSyncConfigs, 
   useSubscribeToSync 
 } from '@/hooks/useSubscriptionSync';
-import { 
-  triggerManualSync, 
-  disableSync, 
+import {
+  ApiError,
+  triggerManualSync,
+  disableSync,
   updateSyncFrequency,
   type User,
   type PlaylistSyncConfig,
-  type SyncResult 
+  type SyncResult
 } from '../../services/api';
 import { toast } from 'sonner';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -151,7 +152,17 @@ export function SyncDashboardClient({ initialUser }: { initialUser: User }) {
       setProcessingConfigId(null);
     },
     onError: (error) => {
-      toast.error('Manual sync failed. Please try again.');
+      // 403 = plan limit reached, 400 = subscription required — both carry a
+      // human-readable detail from the API.
+      if (
+        error instanceof ApiError &&
+        (error.status === 403 || error.status === 400) &&
+        error.detail
+      ) {
+        toast.error(error.detail);
+      } else {
+        toast.error('Manual sync failed. Please try again.');
+      }
       console.error('Manual sync error:', error);
       setProcessingConfigId(null);
     },
@@ -244,7 +255,7 @@ export function SyncDashboardClient({ initialUser }: { initialUser: User }) {
               No Sync Configurations
             </h2>
             <p className="text-muted-foreground mb-4">
-              You haven't enabled sync for any playlists yet. Complete a playlist cleaning job 
+              You haven&apos;t enabled sync for any playlists yet. Complete a playlist cleaning job 
               and enable sync from the job details page.
             </p>
             <Button

--- a/web/src/app/hooks/__tests__/useSubscriptionSync.test.tsx
+++ b/web/src/app/hooks/__tests__/useSubscriptionSync.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { useSubscribeToSync } from '../useSubscriptionSync';
+import { subscribeToSync } from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  getSubscriptionStatus: vi.fn(),
+  getCurrentSubscription: vi.fn(),
+  enableSyncForJob: vi.fn(),
+  subscribeToSync: vi.fn(),
+  getSyncConfigs: vi.fn(),
+}));
+
+// Wrapper whose defaults RETRY mutations, mirroring QueryProvider — the hook
+// must override this with retry: false to avoid duplicate checkout sessions.
+const createRetryingWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: 2, retryDelay: 1 },
+    },
+  });
+  const RetryingWrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return RetryingWrapper;
+};
+
+describe('useSubscribeToSync', () => {
+  let locationStub: { href: string };
+
+  beforeEach(() => {
+    locationStub = { href: 'http://localhost/' };
+    vi.stubGlobal('location', locationStub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not retry a failed checkout even when defaults retry mutations', async () => {
+    (subscribeToSync as Mock).mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useSubscribeToSync(), {
+      wrapper: createRetryingWrapper(),
+    });
+
+    await expect(result.current.mutateAsync()).rejects.toThrow('boom');
+    // A retried mutation would create additional Stripe checkout sessions.
+    expect(subscribeToSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects instead of navigating when the checkout URL is missing', async () => {
+    (subscribeToSync as Mock).mockResolvedValue({});
+
+    const { result } = renderHook(() => useSubscribeToSync(), {
+      wrapper: createRetryingWrapper(),
+    });
+
+    await expect(result.current.mutateAsync()).rejects.toThrow(
+      'Checkout could not be started'
+    );
+    expect(locationStub.href).toBe('http://localhost/');
+  });
+
+  it('redirects to the checkout URL on success', async () => {
+    (subscribeToSync as Mock).mockResolvedValue({
+      checkoutUrl: 'https://checkout.stripe.com/session/abc',
+    });
+
+    const { result } = renderHook(() => useSubscribeToSync(), {
+      wrapper: createRetryingWrapper(),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(locationStub.href).toBe('https://checkout.stripe.com/session/abc');
+    });
+  });
+});

--- a/web/src/app/hooks/__tests__/useSubscriptionSync.test.tsx
+++ b/web/src/app/hooks/__tests__/useSubscriptionSync.test.tsx
@@ -2,8 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
-import { useSubscribeToSync } from '../useSubscriptionSync';
-import { subscribeToSync } from '@/services/api';
+import {
+  useSubscribeToSync,
+  useSubscriptionStatus,
+} from '../useSubscriptionSync';
+import { getSubscriptionStatus, subscribeToSync } from '@/services/api';
 
 vi.mock('@/services/api', () => ({
   getSubscriptionStatus: vi.fn(),
@@ -27,6 +30,39 @@ const createRetryingWrapper = () => {
   );
   return RetryingWrapper;
 };
+
+describe('useSubscriptionStatus', () => {
+  it('refetches on mount even when cached data is still fresh', async () => {
+    (getSubscriptionStatus as Mock).mockResolvedValue({
+      hasActiveSubscription: true,
+    });
+    // Mirror QueryProvider's 5-minute staleTime: without refetchOnMount
+    // 'always', a mounting manage view would show the stale cached value
+    // (e.g. after changes in the Stripe billing portal).
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: 1000 * 60 * 5 },
+      },
+    });
+    queryClient.setQueryData(['subscription-status'], {
+      hasActiveSubscription: false,
+    });
+    const StaleWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSubscriptionStatus(), {
+      wrapper: StaleWrapper,
+    });
+
+    await waitFor(() => {
+      expect(getSubscriptionStatus).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.data?.hasActiveSubscription).toBe(true);
+    });
+  });
+});
 
 describe('useSubscribeToSync', () => {
   let locationStub: { href: string };

--- a/web/src/app/hooks/useSubscriptionSync.ts
+++ b/web/src/app/hooks/useSubscriptionSync.ts
@@ -16,6 +16,11 @@ export const useSubscriptionStatus = () => {
   return useQuery<SubscriptionStatus>({
     queryKey: ['subscription-status'],
     queryFn: getSubscriptionStatus,
+    // Subscription state changes outside the app (Stripe billing portal,
+    // webhooks), so a 5-minute-stale cache can show outdated banners.
+    // Always refetch when a consumer mounts or the window regains focus.
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
   });
 };
 

--- a/web/src/app/hooks/useSubscriptionSync.ts
+++ b/web/src/app/hooks/useSubscriptionSync.ts
@@ -40,10 +40,16 @@ export const useEnableSyncForJob = () => {
 };
 
 export const useSubscribeToSync = () => {
-  const queryClient = useQueryClient();
-  
   return useMutation<{ checkoutUrl: string }, Error>({
-    mutationFn: subscribeToSync,
+    mutationFn: async () => {
+      const data = await subscribeToSync();
+      if (!data?.checkoutUrl) {
+        throw new Error('Checkout could not be started. Please try again.');
+      }
+      return { checkoutUrl: data.checkoutUrl };
+    },
+    // Never retry: each attempt creates a new Stripe checkout session.
+    retry: false,
     onSuccess: (data) => {
       // Redirect to Stripe checkout
       window.location.href = data.checkoutUrl;

--- a/web/src/app/jobs/[jobId]/job-details-client.tsx
+++ b/web/src/app/jobs/[jobId]/job-details-client.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { getJobDetails, Job, User } from '../../services/api';
+import { ApiError, getJobDetails, Job, User } from '../../services/api';
 import TrackMappings from '@/components/ux/TrackMappings';
 import { jobTypeLabel, playlistUrl, providerLabel } from '@/lib/providers';
 import { GlobalHeader } from '@/components/GlobalHeader';
@@ -70,7 +70,17 @@ export function JobDetailsClient({
       await enableSyncMutation.mutateAsync(jobId);
       toast.success('Sync enabled successfully! Your playlist will be synchronized daily.');
     } catch (error) {
-      toast.error('Failed to enable sync. Please try again.');
+      // 403 = plan limit reached, 400 = subscription required — both carry a
+      // human-readable detail from the API.
+      if (
+        error instanceof ApiError &&
+        (error.status === 403 || error.status === 400) &&
+        error.detail
+      ) {
+        toast.error(error.detail);
+      } else {
+        toast.error('Failed to enable sync. Please try again.');
+      }
       console.error('Enable sync error:', error);
     } finally {
       setIsEnablingSync(false);

--- a/web/src/app/providers/QueryProvider.tsx
+++ b/web/src/app/providers/QueryProvider.tsx
@@ -3,30 +3,29 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { authManager } from '@/services/auth';
+import { ApiError } from '@/services/api';
+
+const isAuthError = (error: unknown) =>
+  (error instanceof ApiError && error.status === 401) ||
+  (error instanceof Error && error.message.includes('not authenticated'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5, // 5 minutes
       refetchOnWindowFocus: false,
-      retry: (failureCount, error: any) => {
+      retry: (failureCount, error) => {
         // Don't retry auth errors
-        if (
-          error?.message?.includes('401') ||
-          error?.message?.includes('Authentication')
-        ) {
+        if (isAuthError(error)) {
           return false;
         }
         return failureCount < 3;
       },
     },
     mutations: {
-      retry: (failureCount, error: any) => {
+      retry: (failureCount, error) => {
         // Don't retry auth errors
-        if (
-          error?.message?.includes('401') ||
-          error?.message?.includes('Authentication')
-        ) {
+        if (isAuthError(error)) {
           return false;
         }
         return failureCount < 2;
@@ -37,8 +36,8 @@ const queryClient = new QueryClient({
 
 // Global error handler for auth issues
 queryClient.setMutationDefaults(['auth'], {
-  onError: (error: any) => {
-    if (error?.message?.includes('401')) {
+  onError: (error: unknown) => {
+    if (isAuthError(error)) {
       authManager.logout();
       window.location.href = '/auth';
     }

--- a/web/src/app/services/__tests__/api.test.ts
+++ b/web/src/app/services/__tests__/api.test.ts
@@ -103,6 +103,42 @@ describe('api error handling', () => {
     expect(error.detail).toBeUndefined();
   });
 
+  it('ignores non-string title/detail and falls back to the raw body', async () => {
+    mockFetch.mockResolvedValue(
+      problemResponse(500, { title: 123, detail: { nested: true } })
+    );
+
+    const error = await fetchWithSupabaseAuth(`${API_BASE_URL}/test`).catch(
+      (e) => e
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(typeof error.message).toBe('string');
+    expect(error.message).toBe(
+      JSON.stringify({ title: 123, detail: { nested: true } })
+    );
+    expect(error.detail).toBeUndefined();
+  });
+
+  it('truncates long non-JSON error bodies to ~200 chars', async () => {
+    const longBody = 'x'.repeat(1000);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => longBody,
+      headers: new Headers({ 'content-type': 'text/html' }),
+    });
+
+    const error = await fetchWithSupabaseAuth(`${API_BASE_URL}/test`).catch(
+      (e) => e
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.message.length).toBeLessThanOrEqual(201);
+    expect(error.message.startsWith('x'.repeat(200))).toBe(true);
+  });
+
   it('falls back to statusText when the error body is empty', async () => {
     mockFetch.mockResolvedValue({
       ok: false,

--- a/web/src/app/services/__tests__/api.test.ts
+++ b/web/src/app/services/__tests__/api.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import {
+  ApiError,
+  API_BASE_URL,
+  fetchWithSupabaseAuth,
+  subscribeToSync,
+} from '../api';
+import { createClient } from '@/lib/supabase/client';
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+const mockFetch = global.fetch as Mock;
+
+const problemResponse = (status: number, body: unknown) => ({
+  ok: false,
+  status,
+  statusText: 'Error',
+  text: async () => JSON.stringify(body),
+  headers: new Headers({ 'content-type': 'application/problem+json' }),
+});
+
+describe('api error handling', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    (createClient as Mock).mockReturnValue({
+      auth: {
+        getSession: vi
+          .fn()
+          .mockResolvedValue({ data: { session: { access_token: 'token' } } }),
+      },
+    });
+    consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('throws ApiError carrying status and Problem Details fields', async () => {
+    mockFetch.mockResolvedValue(
+      problemResponse(409, {
+        title: 'Already subscribed',
+        detail: 'You already have an active subscription.',
+        status: 409,
+        type: 'https://radiowash.app/problems/already-subscribed',
+      })
+    );
+
+    const error = await fetchWithSupabaseAuth(`${API_BASE_URL}/test`).catch(
+      (e) => e
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(409);
+    expect(error.message).toBe('Already subscribed');
+    expect(error.detail).toBe('You already have an active subscription.');
+    expect(error.problemType).toBe(
+      'https://radiowash.app/problems/already-subscribed'
+    );
+    // The boundary still logs the raw failure once.
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('uses detail as message when the problem has no title', async () => {
+    mockFetch.mockResolvedValue(
+      problemResponse(503, { detail: 'Subscriptions are unavailable.' })
+    );
+
+    const error = await fetchWithSupabaseAuth(`${API_BASE_URL}/test`).catch(
+      (e) => e
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(503);
+    expect(error.message).toBe('Subscriptions are unavailable.');
+  });
+
+  it('falls back to the raw body for non-JSON error responses', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'Something broke',
+      headers: new Headers({ 'content-type': 'text/plain' }),
+    });
+
+    const error = await fetchWithSupabaseAuth(`${API_BASE_URL}/test`).catch(
+      (e) => e
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(500);
+    expect(error.message).toBe('Something broke');
+    expect(error.detail).toBeUndefined();
+  });
+
+  it('falls back to statusText when the error body is empty', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      text: async () => '',
+      headers: new Headers(),
+    });
+
+    const error = await fetchWithSupabaseAuth(`${API_BASE_URL}/test`).catch(
+      (e) => e
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(502);
+    expect(error.message).toBe('Bad Gateway');
+  });
+
+  it('returns parsed JSON on success', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ hello: 'world' }),
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+
+    await expect(fetchWithSupabaseAuth(`${API_BASE_URL}/test`)).resolves.toEqual(
+      { hello: 'world' }
+    );
+  });
+});
+
+describe('subscribeToSync', () => {
+  beforeEach(() => {
+    (createClient as Mock).mockReturnValue({
+      auth: {
+        getSession: vi
+          .fn()
+          .mockResolvedValue({ data: { session: { access_token: 'token' } } }),
+      },
+    });
+  });
+
+  it('posts planId null and a client request id straight to checkout', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ checkoutUrl: 'https://checkout.stripe.com/x' }),
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+
+    const result = await subscribeToSync();
+
+    expect(result).toEqual({ checkoutUrl: 'https://checkout.stripe.com/x' });
+    // No /plans pre-fetch — a single POST to /checkout.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe(`${API_BASE_URL}/subscription/checkout`);
+    expect(options.method).toBe('POST');
+    const body = JSON.parse(options.body);
+    expect(body.planId).toBeNull();
+    expect(body.clientRequestId).toEqual(expect.any(String));
+    expect(body.clientRequestId.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/app/services/api.ts
+++ b/web/src/app/services/api.ts
@@ -56,10 +56,11 @@ export interface TrackMapping {
 
 export interface SubscriptionStatus {
   hasActiveSubscription: boolean;
-  subscriptionId?: string;
-  planName?: string;
-  status?: string;
-  currentPeriodEnd?: string;
+  subscriptionId: number | null;
+  planName: string | null;
+  status: string | null;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
 }
 
 export interface UserSubscriptionDto {
@@ -68,6 +69,7 @@ export interface UserSubscriptionDto {
   currentPeriodStart?: string;
   currentPeriodEnd?: string;
   canceledAt?: string;
+  cancelAtPeriodEnd?: boolean;
   plan: SubscriptionPlanDto;
   createdAt: string;
 }
@@ -112,6 +114,50 @@ export interface SyncHistory {
 export const API_BASE_URL =
   (process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:5159') + '/api';
 
+// Typed API error carrying the HTTP status and, when the backend returned an
+// RFC 7807 Problem Details body, its human-readable detail and problem type.
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly detail?: string,
+    public readonly problemType?: string
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+// Builds an ApiError from a non-ok response body. Problem Details bodies
+// (title/detail/type) are unpacked; anything else falls back to the raw text.
+const toApiError = (
+  status: number,
+  statusText: string,
+  body: string
+): ApiError => {
+  try {
+    const parsed = JSON.parse(body);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      (typeof parsed.title === 'string' || typeof parsed.detail === 'string')
+    ) {
+      return new ApiError(
+        status,
+        parsed.title ?? parsed.detail,
+        parsed.detail,
+        typeof parsed.type === 'string' ? parsed.type : undefined
+      );
+    }
+  } catch {
+    // Not JSON — fall through to the raw-text fallback.
+  }
+  return new ApiError(
+    status,
+    body || statusText || `Request failed with status ${status}`
+  );
+};
+
 // Server-side API function
 export const fetchWithSupabaseAuthServer = async (
   url: string,
@@ -144,7 +190,7 @@ export const fetchWithSupabaseAuthServer = async (
       `Error Body: "${errorBody}"`,
       `URL: "${url}"`
     );
-    throw new Error(`Request failed: ${response.statusText}`);
+    throw toApiError(response.status, response.statusText, errorBody);
   }
 
   const contentType = response.headers.get('content-type');
@@ -187,7 +233,7 @@ export const fetchWithSupabaseAuth = async (
       `Error Body: "${errorBody}"`,
       `URL: "${url}"`
     );
-    throw new Error(`Request failed: ${response.statusText}`);
+    throw toApiError(response.status, response.statusText, errorBody);
   }
 
   const contentType = response.headers.get('content-type');
@@ -342,22 +388,40 @@ export const getAvailablePlans = (): Promise<SubscriptionPlanDto[]> => {
   return fetchWithSupabaseAuth(`${API_BASE_URL}/subscription/plans`);
 };
 
-export const subscribeToSync = async (): Promise<{ checkoutUrl: string }> => {
-  // Get available plans first
-  const plans = await fetchWithSupabaseAuth(`${API_BASE_URL}/subscription/plans`);
-  if (!plans || plans.length === 0) {
-    throw new Error('No subscription plans available');
-  }
-  
-  // Use the first available plan's Stripe price ID
-  const defaultPlan = plans[0];
+export const subscribeToSync = (): Promise<{ checkoutUrl?: string }> => {
+  // planId null lets the backend pick the default plan; the Stripe price is
+  // resolved server-side. clientRequestId makes the checkout idempotent.
   return fetchWithSupabaseAuth(`${API_BASE_URL}/subscription/checkout`, {
     method: 'POST',
-    body: JSON.stringify({ planPriceId: defaultPlan.stripePriceId }),
+    body: JSON.stringify({ planId: null, clientRequestId: crypto.randomUUID() }),
   });
 };
 
-export const cancelSubscription = (): Promise<{ success: boolean }> => {
+// Reconciles a completed Stripe Checkout session with the local subscription
+// state. Idempotent — safe to call repeatedly.
+export const completeCheckout = (
+  sessionId: string
+): Promise<SubscriptionStatus> => {
+  return fetchWithSupabaseAuth(
+    `${API_BASE_URL}/subscription/checkout/complete`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ sessionId }),
+    }
+  );
+};
+
+export const createPortalSession = (): Promise<{ portalUrl?: string }> => {
+  return fetchWithSupabaseAuth(`${API_BASE_URL}/subscription/portal`, {
+    method: 'POST',
+  });
+};
+
+export const cancelSubscription = (): Promise<{
+  message: string;
+  activeUntil?: string;
+  cancelAtPeriodEnd?: boolean;
+}> => {
   return fetchWithSupabaseAuth(`${API_BASE_URL}/subscription/cancel`, {
     method: 'POST',
   });
@@ -399,7 +463,7 @@ export const triggerManualSync = (syncConfigId: number): Promise<SyncResult> => 
 
 export const getSyncHistory = (
   syncConfigId: number,
-  limit: number = 20
+  limit = 20
 ): Promise<SyncHistory[]> => {
   return fetchWithSupabaseAuth(
     `${API_BASE_URL}/playlistsync/${syncConfigId}/history?limit=${limit}`

--- a/web/src/app/services/api.ts
+++ b/web/src/app/services/api.ts
@@ -128,6 +128,15 @@ export class ApiError extends Error {
   }
 }
 
+// Raw (non-Problem-Details) error bodies can be huge HTML pages — keep only
+// enough to be useful in a message.
+const MAX_RAW_ERROR_BODY_LENGTH = 200;
+
+const truncate = (text: string) =>
+  text.length > MAX_RAW_ERROR_BODY_LENGTH
+    ? `${text.slice(0, MAX_RAW_ERROR_BODY_LENGTH)}…`
+    : text;
+
 // Builds an ApiError from a non-ok response body. Problem Details bodies
 // (title/detail/type) are unpacked; anything else falls back to the raw text.
 const toApiError = (
@@ -137,24 +146,28 @@ const toApiError = (
 ): ApiError => {
   try {
     const parsed = JSON.parse(body);
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      (typeof parsed.title === 'string' || typeof parsed.detail === 'string')
-    ) {
-      return new ApiError(
-        status,
-        parsed.title ?? parsed.detail,
-        parsed.detail,
-        typeof parsed.type === 'string' ? parsed.type : undefined
-      );
+    if (parsed && typeof parsed === 'object') {
+      // Only trust string fields — a numeric or object title/detail must
+      // never become the error message.
+      const title = typeof parsed.title === 'string' ? parsed.title : undefined;
+      const detail =
+        typeof parsed.detail === 'string' ? parsed.detail : undefined;
+      const message = title ?? detail;
+      if (message) {
+        return new ApiError(
+          status,
+          message,
+          detail,
+          typeof parsed.type === 'string' ? parsed.type : undefined
+        );
+      }
     }
   } catch {
     // Not JSON — fall through to the raw-text fallback.
   }
   return new ApiError(
     status,
-    body || statusText || `Request failed with status ${status}`
+    truncate(body) || statusText || `Request failed with status ${status}`
   );
 };
 

--- a/web/src/app/subscription/__tests__/subscription-client.test.tsx
+++ b/web/src/app/subscription/__tests__/subscription-client.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { SubscriptionClient } from '../subscription-client';
+import {
+  ApiError,
+  createPortalSession,
+  type SubscriptionStatus,
+} from '@/services/api';
+import {
+  useSubscriptionStatus,
+  useSubscribeToSync,
+} from '@/hooks/useSubscriptionSync';
+import { toast } from 'sonner';
+import { QueryWrapper } from '@/test-utils/react-query-wrapper';
+
+vi.mock('@/services/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/api')>();
+  return {
+    ...actual,
+    cancelSubscription: vi.fn(),
+    createPortalSession: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/hooks/useSubscriptionSync', () => ({
+  useSubscriptionStatus: vi.fn(),
+  useSubscribeToSync: vi.fn(),
+}));
+
+vi.mock('@/components/GlobalHeader', () => ({
+  GlobalHeader: () => <div data-testid="global-header" />,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const user = {
+  id: 1,
+  spotifyId: 'spotify-1',
+  displayName: 'Test User',
+  email: 'test@example.com',
+};
+
+const activeStatus: SubscriptionStatus = {
+  hasActiveSubscription: true,
+  subscriptionId: 1,
+  planName: 'Sync Plan',
+  status: 'active',
+  currentPeriodEnd: '2026-09-01T00:00:00Z',
+  cancelAtPeriodEnd: false,
+};
+
+const noSubscriptionStatus: SubscriptionStatus = {
+  hasActiveSubscription: false,
+  subscriptionId: null,
+  planName: null,
+  status: null,
+  currentPeriodEnd: null,
+  cancelAtPeriodEnd: false,
+};
+
+const setStatus = (status: SubscriptionStatus) => {
+  (useSubscriptionStatus as Mock).mockReturnValue({
+    data: status,
+    isLoading: false,
+  });
+};
+
+const setSubscribeMutation = (overrides = {}) => {
+  (useSubscribeToSync as Mock).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    ...overrides,
+  });
+};
+
+const renderClient = () =>
+  render(<SubscriptionClient initialUser={user} />, { wrapper: QueryWrapper });
+
+describe('SubscriptionClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setSubscribeMutation();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the already-subscribed message when checkout returns 409', async () => {
+    setStatus(noSubscriptionStatus);
+    setSubscribeMutation({
+      mutateAsync: vi
+        .fn()
+        .mockRejectedValue(
+          new ApiError(
+            409,
+            'Already subscribed',
+            'You already have an active subscription.',
+            'https://radiowash.app/problems/already-subscribed'
+          )
+        ),
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderClient();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Subscribe to Sync/i })
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'You already have an active subscription'
+      );
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows the unavailable message when checkout is disabled (503)', async () => {
+    setStatus(noSubscriptionStatus);
+    setSubscribeMutation({
+      mutateAsync: vi
+        .fn()
+        .mockRejectedValue(
+          new ApiError(
+            503,
+            'Checkout disabled',
+            'Subscriptions are temporarily unavailable. Please try again later.',
+            'https://radiowash.app/problems/checkout-disabled'
+          )
+        ),
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderClient();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Subscribe to Sync/i })
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Subscriptions are temporarily unavailable — please try again later'
+      );
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders the scheduled-cancellation banner and hides the cancel button', () => {
+    setStatus({ ...activeStatus, cancelAtPeriodEnd: true });
+
+    renderClient();
+
+    expect(screen.getByText(/Cancellation scheduled/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Cancel Subscription/i })
+    ).toBeNull();
+    // Billing can still be resumed through the portal.
+    expect(
+      screen.getByRole('button', { name: /Manage billing/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Access until:/i)).toBeInTheDocument();
+  });
+
+  it('shows the cancel button and real plan data for an active subscription', () => {
+    setStatus(activeStatus);
+
+    renderClient();
+
+    expect(
+      screen.getByRole('button', { name: /Cancel Subscription/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Sync Plan')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByText(/Next billing:/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Cancellation scheduled/i)).toBeNull();
+  });
+
+  it('navigates to the billing portal URL from the Manage billing button', async () => {
+    setStatus(activeStatus);
+    (createPortalSession as Mock).mockResolvedValue({
+      portalUrl: 'https://billing.stripe.com/session/xyz',
+    });
+    const locationStub = { href: 'http://localhost/' };
+    vi.stubGlobal('location', locationStub);
+
+    renderClient();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Manage billing/i })
+    );
+
+    await waitFor(() => {
+      expect(locationStub.href).toBe('https://billing.stripe.com/session/xyz');
+    });
+  });
+
+  it('toasts an error when the portal session cannot be created', async () => {
+    setStatus(activeStatus);
+    (createPortalSession as Mock).mockRejectedValue(
+      new ApiError(400, 'No active subscription found')
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderClient();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Manage billing/i })
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Could not open the billing portal. Please try again.'
+      );
+    });
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/web/src/app/subscription/__tests__/subscription-client.test.tsx
+++ b/web/src/app/subscription/__tests__/subscription-client.test.tsx
@@ -159,6 +159,32 @@ describe('SubscriptionClient', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it('shows a friendly message when checkout is rate limited (429)', async () => {
+    setStatus(noSubscriptionStatus);
+    // The rate limiter responds without a Problem Details body, so the
+    // ApiError carries only a raw message.
+    setSubscribeMutation({
+      mutateAsync: vi
+        .fn()
+        .mockRejectedValue(new ApiError(429, 'Too Many Requests')),
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderClient();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Subscribe to Sync/i })
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Too many attempts — please wait a minute and try again'
+      );
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
   it('renders the scheduled-cancellation banner and hides the cancel button', () => {
     setStatus({ ...activeStatus, cancelAtPeriodEnd: true });
 

--- a/web/src/app/subscription/__tests__/subscription-client.test.tsx
+++ b/web/src/app/subscription/__tests__/subscription-client.test.tsx
@@ -209,8 +209,9 @@ describe('SubscriptionClient', () => {
 
   it('toasts an error when the portal session cannot be created', async () => {
     setStatus(activeStatus);
+    // The backend returns 404 when no subscription exists for the user.
     (createPortalSession as Mock).mockRejectedValue(
-      new ApiError(400, 'No active subscription found')
+      new ApiError(404, 'No active subscription found')
     );
     const consoleErrorSpy = vi
       .spyOn(console, 'error')

--- a/web/src/app/subscription/subscription-client.tsx
+++ b/web/src/app/subscription/subscription-client.tsx
@@ -77,6 +77,10 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
           toast.error(
             'Subscriptions are temporarily unavailable — please try again later'
           );
+        } else if (error.status === 429) {
+          // The rate limiter responds without a Problem Details body, so the
+          // generic detail fallback would show a raw message here.
+          toast.error('Too many attempts — please wait a minute and try again');
         } else {
           toast.error(error.detail ?? 'Subscription failed. Please try again.');
         }

--- a/web/src/app/subscription/subscription-client.tsx
+++ b/web/src/app/subscription/subscription-client.tsx
@@ -77,10 +77,6 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
           toast.error(
             'Subscriptions are temporarily unavailable — please try again later'
           );
-        } else if (error.status === 404) {
-          toast.error(
-            'Subscription service not yet configured. Please contact support.'
-          );
         } else {
           toast.error(error.detail ?? 'Subscription failed. Please try again.');
         }

--- a/web/src/app/subscription/subscription-client.tsx
+++ b/web/src/app/subscription/subscription-client.tsx
@@ -6,7 +6,12 @@ import {
   useSubscriptionStatus,
   useSubscribeToSync,
 } from '@/hooks/useSubscriptionSync';
-import { cancelSubscription, type User } from '../services/api';
+import {
+  ApiError,
+  cancelSubscription,
+  createPortalSession,
+  type User,
+} from '../services/api';
 import { toast } from 'sonner';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
@@ -23,16 +28,39 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
   const { data: subscriptionStatus, isLoading } = useSubscriptionStatus();
   const subscribeToSyncMutation = useSubscribeToSync();
 
-  const cancelSubscriptionMutation = useMutation<{ success: boolean }, Error>({
+  const cancelSubscriptionMutation = useMutation<
+    { message: string; activeUntil?: string; cancelAtPeriodEnd?: boolean },
+    Error
+  >({
     mutationFn: cancelSubscription,
-    onSuccess: () => {
-      toast.success('Subscription cancelled successfully');
+    onSuccess: (data) => {
+      // Cancellation happens at period end — access continues until then.
+      toast.success(
+        data.activeUntil
+          ? `Subscription will cancel on ${formatDateTime(data.activeUntil)}`
+          : 'Subscription will cancel at the end of the billing period'
+      );
       queryClient.invalidateQueries({ queryKey: ['subscription-status'] });
-      queryClient.invalidateQueries({ queryKey: ['sync-configs'] });
     },
     onError: (error) => {
       toast.error('Failed to cancel subscription');
       console.error('Cancel subscription error:', error);
+    },
+  });
+
+  const portalMutation = useMutation<{ portalUrl?: string }, Error>({
+    mutationFn: createPortalSession,
+    retry: false,
+    onSuccess: (data) => {
+      if (data?.portalUrl) {
+        window.location.href = data.portalUrl;
+      } else {
+        toast.error('Could not open the billing portal. Please try again.');
+      }
+    },
+    onError: (error) => {
+      toast.error('Could not open the billing portal. Please try again.');
+      console.error('Portal session error:', error);
     },
   });
 
@@ -41,10 +69,21 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
       await subscribeToSyncMutation.mutateAsync();
       // Note: The mutation will redirect to Stripe checkout on success
     } catch (error) {
-      if (error instanceof Error && error.message.includes('404')) {
-        toast.error(
-          'Subscription service not yet configured. Please contact support.'
-        );
+      if (error instanceof ApiError) {
+        if (error.status === 409) {
+          toast.error('You already have an active subscription');
+          queryClient.invalidateQueries({ queryKey: ['subscription-status'] });
+        } else if (error.status === 503) {
+          toast.error(
+            'Subscriptions are temporarily unavailable — please try again later'
+          );
+        } else if (error.status === 404) {
+          toast.error(
+            'Subscription service not yet configured. Please contact support.'
+          );
+        } else {
+          toast.error(error.detail ?? 'Subscription failed. Please try again.');
+        }
       } else {
         toast.error('Subscription failed. Please try again.');
       }
@@ -53,11 +92,12 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
   };
 
   const handleCancelSubscription = async () => {
-    if (
-      confirm(
-        'Are you sure you want to cancel your subscription? This will disable all active sync configurations.'
-      )
-    ) {
+    const accessUntil = subscriptionStatus?.currentPeriodEnd
+      ? ` You'll keep access until ${formatDateTime(
+          subscriptionStatus.currentPeriodEnd
+        )}.`
+      : '';
+    if (confirm(`Cancel your subscription?${accessUntil}`)) {
       await cancelSubscriptionMutation.mutateAsync();
     }
   };
@@ -106,26 +146,42 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
                 </h2>
               </div>
 
+              {subscriptionStatus.cancelAtPeriodEnd && (
+                <div className="bg-warning-muted text-warning rounded-lg p-4 text-sm font-medium">
+                  Cancellation scheduled
+                  {subscriptionStatus.currentPeriodEnd &&
+                    ` — active until ${formatDateTime(
+                      subscriptionStatus.currentPeriodEnd
+                    )}`}
+                </div>
+              )}
+
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <h3 className="font-medium text-foreground">Plan Details</h3>
                   <div className="text-sm space-y-1">
-                    <div>
-                      <span className="text-muted-foreground">Plan:</span>
-                      <span className="ml-2 font-medium">
-                        {subscriptionStatus.planName || 'Sync Plan'}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Status:</span>
-                      <span className="ml-2 font-medium text-success">
-                        {subscriptionStatus.status || 'Active'}
-                      </span>
-                    </div>
+                    {subscriptionStatus.planName && (
+                      <div>
+                        <span className="text-muted-foreground">Plan:</span>
+                        <span className="ml-2 font-medium">
+                          {subscriptionStatus.planName}
+                        </span>
+                      </div>
+                    )}
+                    {subscriptionStatus.status && (
+                      <div>
+                        <span className="text-muted-foreground">Status:</span>
+                        <span className="ml-2 font-medium text-success">
+                          {subscriptionStatus.status}
+                        </span>
+                      </div>
+                    )}
                     {subscriptionStatus.currentPeriodEnd && (
                       <div>
                         <span className="text-muted-foreground">
-                          Next billing:
+                          {subscriptionStatus.cancelAtPeriodEnd
+                            ? 'Access until:'
+                            : 'Next billing:'}
                         </span>
                         <span className="ml-2 font-medium">
                           {formatDateTime(subscriptionStatus.currentPeriodEnd)}
@@ -160,15 +216,31 @@ export function SubscriptionClient({ initialUser }: { initialUser: User }) {
                   Back to Dashboard
                 </Button>
                 <Button
-                  variant="destructive"
-                  onClick={handleCancelSubscription}
-                  disabled={cancelSubscriptionMutation.isPending}
+                  variant="secondary"
+                  onClick={() => portalMutation.mutate()}
+                  disabled={portalMutation.isPending}
                 >
-                  {cancelSubscriptionMutation.isPending
-                    ? 'Cancelling...'
-                    : 'Cancel Subscription'}
+                  {portalMutation.isPending ? 'Opening...' : 'Manage billing'}
                 </Button>
+                {!subscriptionStatus.cancelAtPeriodEnd && (
+                  <Button
+                    variant="destructive"
+                    onClick={handleCancelSubscription}
+                    disabled={cancelSubscriptionMutation.isPending}
+                  >
+                    {cancelSubscriptionMutation.isPending
+                      ? 'Cancelling...'
+                      : 'Cancel Subscription'}
+                  </Button>
+                )}
               </div>
+
+              {subscriptionStatus.cancelAtPeriodEnd && (
+                <p className="text-sm text-muted-foreground">
+                  Changed your mind? You can resume billing from the billing
+                  portal via &quot;Manage billing&quot;.
+                </p>
+              )}
             </div>
           ) : (
             <div className="text-center space-y-8">

--- a/web/src/app/subscription/success/__tests__/subscription-success-client.test.tsx
+++ b/web/src/app/subscription/success/__tests__/subscription-success-client.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { SubscriptionSuccessClient } from '../subscription-success-client';
+import { completeCheckout, getSubscriptionStatus } from '@/services/api';
+import { QueryWrapper } from '@/test-utils/react-query-wrapper';
+
+vi.mock('@/services/api', () => ({
+  completeCheckout: vi.fn(),
+  getSubscriptionStatus: vi.fn(),
+}));
+
+vi.mock('@/components/GlobalHeader', () => ({
+  GlobalHeader: () => <div data-testid="global-header" />,
+}));
+
+const user = {
+  id: 1,
+  spotifyId: 'spotify-1',
+  displayName: 'Test User',
+  email: 'test@example.com',
+};
+
+const activeStatus = {
+  hasActiveSubscription: true,
+  subscriptionId: 1,
+  planName: 'Sync Plan',
+  status: 'active',
+  currentPeriodEnd: '2026-09-01T00:00:00Z',
+  cancelAtPeriodEnd: false,
+};
+
+const inactiveStatus = {
+  ...activeStatus,
+  hasActiveSubscription: false,
+  subscriptionId: null,
+  planName: null,
+  status: null,
+  currentPeriodEnd: null,
+};
+
+const renderClient = (sessionId: string | null) =>
+  render(
+    <SubscriptionSuccessClient initialUser={user} sessionId={sessionId} />,
+    { wrapper: QueryWrapper }
+  );
+
+describe('SubscriptionSuccessClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the activating state first, not an unconditional success', () => {
+    // Reconciliation still in flight.
+    (completeCheckout as Mock).mockReturnValue(new Promise(() => undefined));
+
+    renderClient('cs_test_123');
+
+    expect(
+      screen.getByText(/Activating your subscription/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Subscription Successful!/i)).toBeNull();
+  });
+
+  it('transitions to active when completeCheckout confirms the subscription', async () => {
+    (completeCheckout as Mock).mockResolvedValue(activeStatus);
+
+    renderClient('cs_test_123');
+
+    expect(await screen.findByText(/Subscription Successful!/i)).toBeVisible();
+    expect(completeCheckout).toHaveBeenCalledWith('cs_test_123');
+    expect(getSubscriptionStatus).not.toHaveBeenCalled();
+  });
+
+  it('falls back to polling when completeCheckout fails, then activates', async () => {
+    (completeCheckout as Mock).mockRejectedValue(new Error('404'));
+    (getSubscriptionStatus as Mock).mockResolvedValue(activeStatus);
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    vi.useFakeTimers();
+    renderClient('cs_test_123');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(screen.getByText(/Subscription Successful!/i)).toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows the delayed state after polling times out without activation', async () => {
+    (getSubscriptionStatus as Mock).mockResolvedValue(inactiveStatus);
+
+    vi.useFakeTimers();
+    // No session id (old bookmark) — goes straight to polling.
+    renderClient(null);
+
+    expect(
+      screen.getByText(/Activating your subscription/i)
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31000);
+    });
+
+    expect(screen.getByText(/Payment received/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/activation is taking longer than expected/i)
+    ).toBeInTheDocument();
+    // Reassurance, not an error: the dashboard link is offered.
+    expect(
+      screen.getByRole('button', { name: /Go to Dashboard/i })
+    ).toBeInTheDocument();
+    expect(completeCheckout).not.toHaveBeenCalled();
+    expect(getSubscriptionStatus).toHaveBeenCalled();
+  });
+
+  it('activates from polling as soon as the status flips', async () => {
+    (getSubscriptionStatus as Mock)
+      .mockResolvedValueOnce(inactiveStatus)
+      .mockResolvedValue(activeStatus);
+
+    vi.useFakeTimers();
+    renderClient(null);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+
+    expect(screen.getByText(/Subscription Successful!/i)).toBeInTheDocument();
+  });
+});
+
+describe('SubscriptionSuccessClient without fake timers', () => {
+  it('keeps activating while the status is not yet active', async () => {
+    (completeCheckout as Mock).mockResolvedValue(inactiveStatus);
+    (getSubscriptionStatus as Mock).mockResolvedValue(inactiveStatus);
+
+    renderClient('cs_test_123');
+
+    await waitFor(() => {
+      expect(completeCheckout).toHaveBeenCalled();
+    });
+    expect(
+      screen.getByText(/Activating your subscription/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Subscription Successful!/i)).toBeNull();
+  });
+});

--- a/web/src/app/subscription/success/__tests__/subscription-success-client.test.tsx
+++ b/web/src/app/subscription/success/__tests__/subscription-success-client.test.tsx
@@ -1,12 +1,38 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { SubscriptionSuccessClient } from '../subscription-success-client';
-import { completeCheckout, getSubscriptionStatus } from '@/services/api';
+import { ApiError, completeCheckout, getSubscriptionStatus } from '@/services/api';
 import { QueryWrapper } from '@/test-utils/react-query-wrapper';
 
-vi.mock('@/services/api', () => ({
-  completeCheckout: vi.fn(),
-  getSubscriptionStatus: vi.fn(),
+// The real app router identity is stable across renders — mirror that, or the
+// effect (which depends on `router`) re-runs on every render.
+const { mockRouter, mockReplace } = vi.hoisted(() => {
+  const replace = vi.fn();
+  return {
+    mockReplace: replace,
+    mockRouter: { refresh: vi.fn(), push: vi.fn(), replace },
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => mockRouter,
+}));
+
+vi.mock('@/services/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/api')>();
+  return {
+    ...actual,
+    completeCheckout: vi.fn(),
+    getSubscriptionStatus: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
 }));
 
 vi.mock('@/components/GlobalHeader', () => ({
@@ -44,7 +70,13 @@ const renderClient = (sessionId: string | null) =>
     { wrapper: QueryWrapper }
   );
 
-describe('SubscriptionSuccessClient', () => {
+const expectNoPaymentClaims = () => {
+  expect(screen.queryByText(/payment received/i)).toBeNull();
+  expect(screen.queryByText(/confirming your payment/i)).toBeNull();
+  expect(screen.queryByText(/Subscription Successful!/i)).toBeNull();
+};
+
+describe('SubscriptionSuccessClient with a checkout session', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -75,8 +107,10 @@ describe('SubscriptionSuccessClient', () => {
     expect(getSubscriptionStatus).not.toHaveBeenCalled();
   });
 
-  it('falls back to polling when completeCheckout fails, then activates', async () => {
-    (completeCheckout as Mock).mockRejectedValue(new Error('404'));
+  it('falls back to polling when completeCheckout fails transiently, then activates', async () => {
+    (completeCheckout as Mock).mockRejectedValue(
+      new ApiError(500, 'Internal Server Error')
+    );
     (getSubscriptionStatus as Mock).mockResolvedValue(activeStatus);
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
@@ -93,46 +127,173 @@ describe('SubscriptionSuccessClient', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('shows the delayed state after polling times out without activation', async () => {
+  it('retries completeCheckout during the poll window after a 500, then activates', async () => {
+    (completeCheckout as Mock)
+      .mockRejectedValueOnce(new ApiError(500, 'Internal Server Error'))
+      .mockResolvedValue(activeStatus);
+    (getSubscriptionStatus as Mock).mockResolvedValue(inactiveStatus);
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    vi.useFakeTimers();
+    renderClient('cs_test_123');
+
+    // Tick 1 polls GET /status (inactive); tick 2 retries the idempotent
+    // checkout/complete, which now succeeds.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+
+    expect(completeCheckout).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(/Subscription Successful!/i)).toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows a neutral unverified state on 404 without polling or payment claims', async () => {
+    (completeCheckout as Mock).mockRejectedValue(
+      new ApiError(404, 'Checkout session not found')
+    );
+
+    vi.useFakeTimers();
+    renderClient('cs_test_123');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(
+      screen.getByText(/couldn.t verify this checkout session/i)
+    ).toBeInTheDocument();
+    expectNoPaymentClaims();
+    expect(
+      screen.getByRole('button', { name: /Go to Subscription/i })
+    ).toBeInTheDocument();
+
+    // No poll loop starts on behalf of a rejected session.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+    expect(getSubscriptionStatus).not.toHaveBeenCalled();
+    expect(completeCheckout).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a neutral unverified state on 403 without polling or payment claims', async () => {
+    (completeCheckout as Mock).mockRejectedValue(
+      new ApiError(403, 'Session belongs to another user')
+    );
+
+    vi.useFakeTimers();
+    renderClient('cs_test_123');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+
+    expect(
+      screen.getByText(/couldn.t verify this checkout session/i)
+    ).toBeInTheDocument();
+    expectNoPaymentClaims();
+    expect(getSubscriptionStatus).not.toHaveBeenCalled();
+  });
+
+  it('keeps polling in the delayed state and activates when the status flips', async () => {
+    (completeCheckout as Mock).mockResolvedValue(inactiveStatus);
     (getSubscriptionStatus as Mock).mockResolvedValue(inactiveStatus);
 
     vi.useFakeTimers();
-    // No session id (old bookmark) — goes straight to polling.
-    renderClient(null);
-
-    expect(
-      screen.getByText(/Activating your subscription/i)
-    ).toBeInTheDocument();
+    renderClient('cs_test_123');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(31000);
     });
 
-    expect(screen.getByText(/Payment received/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/activation is taking longer than expected/i)
-    ).toBeInTheDocument();
-    // Reassurance, not an error: the dashboard link is offered.
+    // Copy matches behavior: the page says it keeps checking, and it does.
+    expect(screen.getByText(/Still activating/i)).toBeInTheDocument();
+    expect(screen.getByText(/keeps checking automatically/i)).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Go to Dashboard/i })
     ).toBeInTheDocument();
-    expect(completeCheckout).not.toHaveBeenCalled();
-    expect(getSubscriptionStatus).toHaveBeenCalled();
+
+    const pollsBeforeDelay = (getSubscriptionStatus as Mock).mock.calls.length;
+    (getSubscriptionStatus as Mock).mockResolvedValue(activeStatus);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+
+    expect((getSubscriptionStatus as Mock).mock.calls.length).toBeGreaterThan(
+      pollsBeforeDelay
+    );
+    expect(screen.getByText(/Subscription Successful!/i)).toBeInTheDocument();
   });
 
   it('activates from polling as soon as the status flips', async () => {
+    (completeCheckout as Mock).mockResolvedValue(inactiveStatus);
     (getSubscriptionStatus as Mock)
       .mockResolvedValueOnce(inactiveStatus)
       .mockResolvedValue(activeStatus);
 
     vi.useFakeTimers();
-    renderClient(null);
+    renderClient('cs_test_123');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4000);
     });
 
     expect(screen.getByText(/Subscription Successful!/i)).toBeInTheDocument();
+  });
+});
+
+describe('SubscriptionSuccessClient without a checkout session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('checks the status neutrally and redirects inactive users to /subscription', async () => {
+    (getSubscriptionStatus as Mock).mockResolvedValue(inactiveStatus);
+
+    renderClient(null);
+
+    // Neutral copy while checking — no payment language on a direct visit.
+    expect(
+      screen.getByText(/Checking subscription status/i)
+    ).toBeInTheDocument();
+    expectNoPaymentClaims();
+    expect(screen.queryByText(/Activating your subscription/i)).toBeNull();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/subscription');
+    });
+    expectNoPaymentClaims();
+    expect(completeCheckout).not.toHaveBeenCalled();
+  });
+
+  it('shows the success view when the subscription is already active', async () => {
+    (getSubscriptionStatus as Mock).mockResolvedValue(activeStatus);
+
+    renderClient(null);
+
+    expect(await screen.findByText(/Subscription Successful!/i)).toBeVisible();
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(completeCheckout).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /subscription when the status check fails', async () => {
+    (getSubscriptionStatus as Mock).mockRejectedValue(
+      new ApiError(500, 'Internal Server Error')
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderClient(null);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/subscription');
+    });
+    expectNoPaymentClaims();
+    consoleErrorSpy.mockRestore();
   });
 });
 

--- a/web/src/app/subscription/success/__tests__/subscription-success-client.test.tsx
+++ b/web/src/app/subscription/success/__tests__/subscription-success-client.test.tsx
@@ -243,6 +243,76 @@ describe('SubscriptionSuccessClient with a checkout session', () => {
 
     expect(screen.getByText(/Subscription Successful!/i)).toBeInTheDocument();
   });
+
+  it('redirects to /auth when the initial reconcile hits a 401', async () => {
+    (completeCheckout as Mock).mockRejectedValue(
+      new ApiError(401, 'User not authenticated')
+    );
+
+    vi.useFakeTimers();
+    renderClient('cs_test_123');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith('/auth');
+
+    // No poll loop starts on behalf of an expired session.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+    expect(getSubscriptionStatus).not.toHaveBeenCalled();
+  });
+
+  it('stops polling and redirects to /auth when the session expires mid-poll', async () => {
+    (completeCheckout as Mock).mockResolvedValue(inactiveStatus);
+    (getSubscriptionStatus as Mock).mockRejectedValue(
+      new ApiError(401, 'User not authenticated')
+    );
+
+    vi.useFakeTimers();
+    renderClient('cs_test_123');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith('/auth');
+
+    const pollsAtRedirect = (getSubscriptionStatus as Mock).mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+    expect((getSubscriptionStatus as Mock).mock.calls.length).toBe(
+      pollsAtRedirect
+    );
+  });
+
+  it('stops checking at the hard cap and says so', async () => {
+    (completeCheckout as Mock).mockResolvedValue(inactiveStatus);
+    (getSubscriptionStatus as Mock).mockResolvedValue(inactiveStatus);
+
+    vi.useFakeTimers();
+    renderClient('cs_test_123');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
+    });
+
+    // Copy matches behavior: the page says it stopped checking, and it has.
+    expect(screen.getByText(/Activation still pending/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/stopped checking automatically/i)
+    ).toBeInTheDocument();
+    expectNoPaymentClaims();
+
+    const pollsAtCap = (getSubscriptionStatus as Mock).mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+    expect((getSubscriptionStatus as Mock).mock.calls.length).toBe(pollsAtCap);
+  });
 });
 
 describe('SubscriptionSuccessClient without a checkout session', () => {
@@ -279,7 +349,30 @@ describe('SubscriptionSuccessClient without a checkout session', () => {
     expect(completeCheckout).not.toHaveBeenCalled();
   });
 
-  it('redirects to /subscription when the status check fails', async () => {
+  it('retries a transiently failing status check before giving up', async () => {
+    (getSubscriptionStatus as Mock)
+      .mockRejectedValueOnce(new ApiError(500, 'Internal Server Error'))
+      .mockResolvedValue(activeStatus);
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    vi.useFakeTimers();
+    renderClient(null);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    // A subscribed user is not bounced by one transient failure.
+    expect(screen.getByText(/Subscription Successful!/i)).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(getSubscriptionStatus).toHaveBeenCalledTimes(2);
+    consoleErrorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('redirects to /subscription when the status check keeps failing', async () => {
     (getSubscriptionStatus as Mock).mockRejectedValue(
       new ApiError(500, 'Internal Server Error')
     );
@@ -287,13 +380,33 @@ describe('SubscriptionSuccessClient without a checkout session', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);
 
+    vi.useFakeTimers();
+    renderClient(null);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith('/subscription');
+    expect(getSubscriptionStatus).toHaveBeenCalledTimes(2);
+    expectNoPaymentClaims();
+    consoleErrorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('redirects to /auth when the status check hits a 401', async () => {
+    (getSubscriptionStatus as Mock).mockRejectedValue(
+      new ApiError(401, 'User not authenticated')
+    );
+
     renderClient(null);
 
     await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith('/subscription');
+      expect(mockReplace).toHaveBeenCalledWith('/auth');
     });
+    // 401 is terminal — no retry.
+    expect(getSubscriptionStatus).toHaveBeenCalledTimes(1);
     expectNoPaymentClaims();
-    consoleErrorSpy.mockRestore();
   });
 });
 

--- a/web/src/app/subscription/success/page.tsx
+++ b/web/src/app/subscription/success/page.tsx
@@ -1,8 +1,15 @@
 import { getMeServer } from '../../services/api';
 import { SubscriptionSuccessClient } from './subscription-success-client';
 
-export default async function SubscriptionSuccessPage() {
+export default async function SubscriptionSuccessPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ session_id?: string }>;
+}) {
   const user = await getMeServer();
+  const { session_id: sessionId } = await searchParams;
 
-  return <SubscriptionSuccessClient initialUser={user} />;
+  return (
+    <SubscriptionSuccessClient initialUser={user} sessionId={sessionId ?? null} />
+  );
 }

--- a/web/src/app/subscription/success/subscription-success-client.tsx
+++ b/web/src/app/subscription/success/subscription-success-client.tsx
@@ -15,19 +15,28 @@ import { useQueryClient } from '@tanstack/react-query';
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 30000;
 const DELAYED_POLL_INTERVAL_MS = 10000;
+// An activation that hasn't confirmed by now isn't going to confirm from this
+// tab — stop polling instead of hitting the API forever from abandoned tabs.
+const MAX_POLL_DURATION_MS = 10 * 60 * 1000;
 
 type ActivationState =
   | 'checking' // no session id — verifying the current status, no payment claims
   | 'activating' // fresh checkout session being reconciled
   | 'active'
   | 'delayed'
-  | 'unverified'; // the checkout session was rejected (403/404)
+  | 'unverified' // the checkout session was rejected (403/404)
+  | 'stalled'; // polling hit the hard cap without confirmation
 
 // 403/404 mean the session doesn't exist or belongs to another user —
 // retrying cannot succeed, and no payment can be claimed.
 const isSessionRejection = (error: unknown) =>
   error instanceof ApiError &&
   (error.status === 403 || error.status === 404);
+
+// A 401 means the session expired — no amount of polling can succeed until
+// the user signs in again.
+const isAuthExpiry = (error: unknown) =>
+  error instanceof ApiError && error.status === 401;
 
 export function SubscriptionSuccessClient({
   initialUser,
@@ -44,8 +53,10 @@ export function SubscriptionSuccessClient({
 
   useEffect(() => {
     let cancelled = false;
+    let stopped = false;
     let pollTimerId: ReturnType<typeof setTimeout> | undefined;
     let deadlineId: ReturnType<typeof setTimeout> | undefined;
+    let hardStopId: ReturnType<typeof setTimeout> | undefined;
     let delayed = false;
     let needsReconcile = false;
     let tick = 0;
@@ -53,6 +64,7 @@ export function SubscriptionSuccessClient({
     const stopTimers = () => {
       if (pollTimerId) clearTimeout(pollTimerId);
       if (deadlineId) clearTimeout(deadlineId);
+      if (hardStopId) clearTimeout(hardStopId);
     };
 
     const activate = () => {
@@ -66,7 +78,7 @@ export function SubscriptionSuccessClient({
     // One status request at a time: each completed request schedules the
     // next via setTimeout, so slow responses never stack.
     const scheduleNextPoll = () => {
-      if (cancelled) return;
+      if (cancelled || stopped) return;
       pollTimerId = setTimeout(
         pollOnce,
         delayed ? DELAYED_POLL_INTERVAL_MS : POLL_INTERVAL_MS
@@ -101,6 +113,11 @@ export function SubscriptionSuccessClient({
           setState('unverified');
           return;
         }
+        if (isAuthExpiry(error)) {
+          stopTimers();
+          router.replace('/auth');
+          return;
+        }
         // Transient failure — keep polling.
         console.error('Subscription status poll failed:', error);
       }
@@ -108,7 +125,8 @@ export function SubscriptionSuccessClient({
     };
 
     // Poll the subscription status until the webhook lands. After the
-    // deadline, switch to the slower "delayed" cadence but keep checking.
+    // deadline, switch to the slower "delayed" cadence but keep checking —
+    // until the hard cap, after which the page stops and says so.
     const startPolling = () => {
       if (cancelled) return;
       deadlineId = setTimeout(() => {
@@ -116,27 +134,50 @@ export function SubscriptionSuccessClient({
         delayed = true;
         setState((current) => (current === 'activating' ? 'delayed' : current));
       }, POLL_TIMEOUT_MS);
+      hardStopId = setTimeout(() => {
+        if (cancelled) return;
+        stopped = true;
+        stopTimers();
+        setState((current) =>
+          current === 'activating' || current === 'delayed'
+            ? 'stalled'
+            : current
+        );
+      }, MAX_POLL_DURATION_MS);
       scheduleNextPoll();
     };
 
     const run = async () => {
       if (!sessionId) {
         // Old bookmark or direct visit — nothing to reconcile and no payment
-        // to claim. Check once: active users see the success view, everyone
-        // else goes to the subscription page.
-        try {
-          const status = await getSubscriptionStatus();
-          if (cancelled) return;
-          if (status?.hasActiveSubscription) {
-            activate();
-          } else {
-            router.replace('/subscription');
+        // to claim. A subscribed user shouldn't be bounced by one transient
+        // failure, so retry the check once before redirecting.
+        for (let attempt = 0; attempt < 2; attempt++) {
+          try {
+            const status = await getSubscriptionStatus();
+            if (cancelled) return;
+            if (status?.hasActiveSubscription) {
+              activate();
+            } else {
+              router.replace('/subscription');
+            }
+            return;
+          } catch (error) {
+            if (cancelled) return;
+            if (isAuthExpiry(error)) {
+              router.replace('/auth');
+              return;
+            }
+            console.error('Subscription status check failed:', error);
+            if (attempt === 0) {
+              await new Promise((resolve) =>
+                setTimeout(resolve, POLL_INTERVAL_MS)
+              );
+              if (cancelled) return;
+            }
           }
-        } catch (error) {
-          if (cancelled) return;
-          console.error('Subscription status check failed:', error);
-          router.replace('/subscription');
         }
+        router.replace('/subscription');
         return;
       }
       try {
@@ -154,6 +195,10 @@ export function SubscriptionSuccessClient({
           // The session was rejected outright — don't claim a payment
           // happened, and don't poll on its behalf.
           setState('unverified');
+          return;
+        }
+        if (isAuthExpiry(error)) {
+          router.replace('/auth');
           return;
         }
         // Transient reconciliation failure (5xx / network). The endpoint is
@@ -244,6 +289,41 @@ export function SubscriptionSuccessClient({
               className="bg-info hover:bg-info-hover text-info-foreground"
             >
               Go to Dashboard
+            </Button>
+          </div>
+        )}
+
+        {state === 'stalled' && (
+          <div className="text-center">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-warning-muted mb-4">
+              <svg
+                className="h-6 w-6 text-warning"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0"
+                />
+              </svg>
+            </div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              Activation still pending
+            </h1>
+            <p className="text-lg text-muted-foreground mb-8 max-w-xl mx-auto">
+              We&apos;ve stopped checking automatically. Your payment may still
+              be processing — check the subscription page in a few minutes, and
+              contact support if your subscription doesn&apos;t appear.
+            </p>
+            <Button
+              onClick={() => router.push('/subscription')}
+              size="lg"
+              className="bg-brand hover:bg-brand-hover text-brand-foreground"
+            >
+              Go to Subscription
             </Button>
           </div>
         )}

--- a/web/src/app/subscription/success/subscription-success-client.tsx
+++ b/web/src/app/subscription/success/subscription-success-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { GlobalHeader } from '@/components/GlobalHeader';
 import { Button } from '@/components/ui/button';
 import {
+  ApiError,
   completeCheckout,
   getSubscriptionStatus,
   type User,
@@ -13,8 +14,20 @@ import { useQueryClient } from '@tanstack/react-query';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 30000;
+const DELAYED_POLL_INTERVAL_MS = 10000;
 
-type ActivationState = 'activating' | 'active' | 'delayed';
+type ActivationState =
+  | 'checking' // no session id — verifying the current status, no payment claims
+  | 'activating' // fresh checkout session being reconciled
+  | 'active'
+  | 'delayed'
+  | 'unverified'; // the checkout session was rejected (403/404)
+
+// 403/404 mean the session doesn't exist or belongs to another user —
+// retrying cannot succeed, and no payment can be claimed.
+const isSessionRejection = (error: unknown) =>
+  error instanceof ApiError &&
+  (error.status === 403 || error.status === 404);
 
 export function SubscriptionSuccessClient({
   initialUser,
@@ -25,16 +38,21 @@ export function SubscriptionSuccessClient({
 }) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [state, setState] = useState<ActivationState>('activating');
+  const [state, setState] = useState<ActivationState>(
+    sessionId ? 'activating' : 'checking'
+  );
 
   useEffect(() => {
     let cancelled = false;
-    let intervalId: ReturnType<typeof setInterval> | undefined;
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let pollTimerId: ReturnType<typeof setTimeout> | undefined;
+    let deadlineId: ReturnType<typeof setTimeout> | undefined;
+    let delayed = false;
+    let needsReconcile = false;
+    let tick = 0;
 
     const stopTimers = () => {
-      if (intervalId) clearInterval(intervalId);
-      if (timeoutId) clearTimeout(timeoutId);
+      if (pollTimerId) clearTimeout(pollTimerId);
+      if (deadlineId) clearTimeout(deadlineId);
     };
 
     const activate = () => {
@@ -45,47 +63,103 @@ export function SubscriptionSuccessClient({
       setState('active');
     };
 
-    // Poll the subscription status until the webhook lands, then give a
-    // reassuring "still working on it" message rather than an error — the
-    // payment itself has already succeeded.
+    // One status request at a time: each completed request schedules the
+    // next via setTimeout, so slow responses never stack.
+    const scheduleNextPoll = () => {
+      if (cancelled) return;
+      pollTimerId = setTimeout(
+        pollOnce,
+        delayed ? DELAYED_POLL_INTERVAL_MS : POLL_INTERVAL_MS
+      );
+    };
+
+    const pollOnce = async () => {
+      if (cancelled) return;
+      tick += 1;
+      // checkout/complete is idempotent and designed for retry — after a
+      // transient failure, re-attempt it on every other tick instead of
+      // relying solely on GET /status.
+      const reconcileThisTick =
+        needsReconcile && !!sessionId && tick % 2 === 0;
+      try {
+        let status;
+        if (reconcileThisTick && sessionId) {
+          status = await completeCheckout(sessionId);
+          needsReconcile = false;
+        } else {
+          status = await getSubscriptionStatus();
+        }
+        if (cancelled) return;
+        if (status?.hasActiveSubscription) {
+          activate();
+          return;
+        }
+      } catch (error) {
+        if (cancelled) return;
+        if (reconcileThisTick && isSessionRejection(error)) {
+          stopTimers();
+          setState('unverified');
+          return;
+        }
+        // Transient failure — keep polling.
+        console.error('Subscription status poll failed:', error);
+      }
+      scheduleNextPoll();
+    };
+
+    // Poll the subscription status until the webhook lands. After the
+    // deadline, switch to the slower "delayed" cadence but keep checking.
     const startPolling = () => {
       if (cancelled) return;
-      intervalId = setInterval(async () => {
-        try {
-          const status = await getSubscriptionStatus();
-          if (status?.hasActiveSubscription) {
-            activate();
-          }
-        } catch (error) {
-          // Transient failure — keep polling until the deadline.
-          console.error('Subscription status poll failed:', error);
-        }
-      }, POLL_INTERVAL_MS);
-      timeoutId = setTimeout(() => {
+      deadlineId = setTimeout(() => {
         if (cancelled) return;
-        if (intervalId) clearInterval(intervalId);
+        delayed = true;
         setState((current) => (current === 'activating' ? 'delayed' : current));
       }, POLL_TIMEOUT_MS);
+      scheduleNextPoll();
     };
 
     const run = async () => {
       if (!sessionId) {
-        // Old bookmark or direct visit — no session to reconcile.
-        startPolling();
+        // Old bookmark or direct visit — nothing to reconcile and no payment
+        // to claim. Check once: active users see the success view, everyone
+        // else goes to the subscription page.
+        try {
+          const status = await getSubscriptionStatus();
+          if (cancelled) return;
+          if (status?.hasActiveSubscription) {
+            activate();
+          } else {
+            router.replace('/subscription');
+          }
+        } catch (error) {
+          if (cancelled) return;
+          console.error('Subscription status check failed:', error);
+          router.replace('/subscription');
+        }
         return;
       }
       try {
         const status = await completeCheckout(sessionId);
+        if (cancelled) return;
         if (status?.hasActiveSubscription) {
           activate();
         } else {
+          // Reconciled, but the webhook hasn't landed yet — poll GET /status.
           startPolling();
         }
       } catch (error) {
-        // Reconciliation failed (e.g. session not found yet, or it belongs to
-        // an older login). The webhook may still activate the subscription, so
-        // fall back to polling instead of alarming the user.
+        if (cancelled) return;
+        if (isSessionRejection(error)) {
+          // The session was rejected outright — don't claim a payment
+          // happened, and don't poll on its behalf.
+          setState('unverified');
+          return;
+        }
+        // Transient reconciliation failure (5xx / network). The endpoint is
+        // idempotent, so retry it during the poll window.
         console.error('Checkout completion failed:', error);
+        needsReconcile = true;
         startPolling();
       }
     };
@@ -96,7 +170,7 @@ export function SubscriptionSuccessClient({
       cancelled = true;
       stopTimers();
     };
-  }, [sessionId, queryClient]);
+  }, [sessionId, queryClient, router]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -107,6 +181,22 @@ export function SubscriptionSuccessClient({
         backButtonLabel="Back to Dashboard"
       />
       <main className="max-w-4xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+        {state === 'checking' && (
+          <div className="text-center">
+            <div
+              className="mx-auto h-12 w-12 rounded-full border-4 border-muted border-t-brand animate-spin mb-4"
+              role="status"
+              aria-label="Checking"
+            ></div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              Checking subscription status…
+            </h1>
+            <p className="text-lg text-muted-foreground">
+              One moment while we look up your subscription.
+            </p>
+          </div>
+        )}
+
         {state === 'activating' && (
           <div className="text-center">
             <div
@@ -141,11 +231,12 @@ export function SubscriptionSuccessClient({
               </svg>
             </div>
             <h1 className="text-3xl font-bold text-foreground mb-2">
-              Payment received
+              Still activating…
             </h1>
             <p className="text-lg text-muted-foreground mb-8 max-w-xl mx-auto">
-              Activation is taking longer than expected. Your subscription will
-              appear shortly.
+              Activation is taking longer than expected. This page keeps
+              checking automatically — you can also head to the dashboard and
+              come back later.
             </p>
             <Button
               onClick={() => router.push('/dashboard')}
@@ -153,6 +244,40 @@ export function SubscriptionSuccessClient({
               className="bg-info hover:bg-info-hover text-info-foreground"
             >
               Go to Dashboard
+            </Button>
+          </div>
+        )}
+
+        {state === 'unverified' && (
+          <div className="text-center">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-warning-muted mb-4">
+              <svg
+                className="h-6 w-6 text-warning"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                />
+              </svg>
+            </div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              We couldn&apos;t verify this checkout session
+            </h1>
+            <p className="text-lg text-muted-foreground mb-8 max-w-xl mx-auto">
+              This link may be outdated or belong to a different account. Check
+              your subscription status on the subscription page.
+            </p>
+            <Button
+              onClick={() => router.push('/subscription')}
+              size="lg"
+              className="bg-brand hover:bg-brand-hover text-brand-foreground"
+            >
+              Go to Subscription
             </Button>
           </div>
         )}

--- a/web/src/app/subscription/success/subscription-success-client.tsx
+++ b/web/src/app/subscription/success/subscription-success-client.tsx
@@ -1,21 +1,102 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { GlobalHeader } from '@/components/GlobalHeader';
 import { Button } from '@/components/ui/button';
-import { type User } from '../../services/api';
+import {
+  completeCheckout,
+  getSubscriptionStatus,
+  type User,
+} from '../../services/api';
 import { useQueryClient } from '@tanstack/react-query';
 
-export function SubscriptionSuccessClient({ initialUser }: { initialUser: User }) {
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 30000;
+
+type ActivationState = 'activating' | 'active' | 'delayed';
+
+export function SubscriptionSuccessClient({
+  initialUser,
+  sessionId,
+}: {
+  initialUser: User;
+  sessionId?: string | null;
+}) {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const [state, setState] = useState<ActivationState>('activating');
 
   useEffect(() => {
-    // Invalidate subscription-related queries to refetch updated status
-    queryClient.invalidateQueries({ queryKey: ['subscription-status'] });
-    queryClient.invalidateQueries({ queryKey: ['current-subscription'] });
-  }, [queryClient]);
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const stopTimers = () => {
+      if (intervalId) clearInterval(intervalId);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+
+    const activate = () => {
+      if (cancelled) return;
+      stopTimers();
+      queryClient.invalidateQueries({ queryKey: ['subscription-status'] });
+      queryClient.invalidateQueries({ queryKey: ['current-subscription'] });
+      setState('active');
+    };
+
+    // Poll the subscription status until the webhook lands, then give a
+    // reassuring "still working on it" message rather than an error — the
+    // payment itself has already succeeded.
+    const startPolling = () => {
+      if (cancelled) return;
+      intervalId = setInterval(async () => {
+        try {
+          const status = await getSubscriptionStatus();
+          if (status?.hasActiveSubscription) {
+            activate();
+          }
+        } catch (error) {
+          // Transient failure — keep polling until the deadline.
+          console.error('Subscription status poll failed:', error);
+        }
+      }, POLL_INTERVAL_MS);
+      timeoutId = setTimeout(() => {
+        if (cancelled) return;
+        if (intervalId) clearInterval(intervalId);
+        setState((current) => (current === 'activating' ? 'delayed' : current));
+      }, POLL_TIMEOUT_MS);
+    };
+
+    const run = async () => {
+      if (!sessionId) {
+        // Old bookmark or direct visit — no session to reconcile.
+        startPolling();
+        return;
+      }
+      try {
+        const status = await completeCheckout(sessionId);
+        if (status?.hasActiveSubscription) {
+          activate();
+        } else {
+          startPolling();
+        }
+      } catch (error) {
+        // Reconciliation failed (e.g. session not found yet, or it belongs to
+        // an older login). The webhook may still activate the subscription, so
+        // fall back to polling instead of alarming the user.
+        console.error('Checkout completion failed:', error);
+        startPolling();
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      stopTimers();
+    };
+  }, [sessionId, queryClient]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -26,54 +107,46 @@ export function SubscriptionSuccessClient({ initialUser }: { initialUser: User }
         backButtonLabel="Back to Dashboard"
       />
       <main className="max-w-4xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-        <div className="text-center">
-          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-success-muted mb-4">
-            <svg
-              className="h-6 w-6 text-success"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
+        {state === 'activating' && (
+          <div className="text-center">
+            <div
+              className="mx-auto h-12 w-12 rounded-full border-4 border-muted border-t-brand animate-spin mb-4"
+              role="status"
+              aria-label="Activating"
+            ></div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              Activating your subscription…
+            </h1>
+            <p className="text-lg text-muted-foreground">
+              Hang tight — we&apos;re confirming your payment with Stripe.
+            </p>
           </div>
-          
-          <h1 className="text-3xl font-bold text-foreground mb-2">
-            Subscription Successful!
-          </h1>
-          
-          <p className="text-lg text-muted-foreground mb-8">
-            Welcome to RadioWash Sync! You can now enable automatic playlist synchronization.
-          </p>
+        )}
 
-          <div className="bg-card border border-border rounded-lg p-6 max-w-md mx-auto mb-8">
-            <h2 className="text-lg font-semibold text-foreground mb-4">What's Next?</h2>
-            <ul className="space-y-2 text-sm text-muted-foreground text-left">
-              <li className="flex items-center">
-                <span className="text-success mr-2">✓</span>
-                Complete a playlist cleaning job
-              </li>
-              <li className="flex items-center">
-                <span className="text-success mr-2">✓</span>
-                Enable sync from the job details page
-              </li>
-              <li className="flex items-center">
-                <span className="text-success mr-2">✓</span>
-                Manage your sync configurations
-              </li>
-              <li className="flex items-center">
-                <span className="text-success mr-2">✓</span>
-                Enjoy automatic daily synchronization
-              </li>
-            </ul>
-          </div>
-
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+        {state === 'delayed' && (
+          <div className="text-center">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-info-muted mb-4">
+              <svg
+                className="h-6 w-6 text-info"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0"
+                />
+              </svg>
+            </div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              Payment received
+            </h1>
+            <p className="text-lg text-muted-foreground mb-8 max-w-xl mx-auto">
+              Activation is taking longer than expected. Your subscription will
+              appear shortly.
+            </p>
             <Button
               onClick={() => router.push('/dashboard')}
               size="lg"
@@ -81,15 +154,78 @@ export function SubscriptionSuccessClient({ initialUser }: { initialUser: User }
             >
               Go to Dashboard
             </Button>
-            <Button
-              onClick={() => router.push('/subscription')}
-              variant="outline"
-              size="lg"
-            >
-              Manage Subscription
-            </Button>
           </div>
-        </div>
+        )}
+
+        {state === 'active' && (
+          <div className="text-center">
+            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-success-muted mb-4">
+              <svg
+                className="h-6 w-6 text-success"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              Subscription Successful!
+            </h1>
+
+            <p className="text-lg text-muted-foreground mb-8">
+              Welcome to RadioWash Sync! You can now enable automatic playlist
+              synchronization.
+            </p>
+
+            <div className="bg-card border border-border rounded-lg p-6 max-w-md mx-auto mb-8">
+              <h2 className="text-lg font-semibold text-foreground mb-4">
+                What&apos;s Next?
+              </h2>
+              <ul className="space-y-2 text-sm text-muted-foreground text-left">
+                <li className="flex items-center">
+                  <span className="text-success mr-2">✓</span>
+                  Complete a playlist cleaning job
+                </li>
+                <li className="flex items-center">
+                  <span className="text-success mr-2">✓</span>
+                  Enable sync from the job details page
+                </li>
+                <li className="flex items-center">
+                  <span className="text-success mr-2">✓</span>
+                  Manage your sync configurations
+                </li>
+                <li className="flex items-center">
+                  <span className="text-success mr-2">✓</span>
+                  Enjoy automatic daily synchronization
+                </li>
+              </ul>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Button
+                onClick={() => router.push('/dashboard')}
+                size="lg"
+                className="bg-info hover:bg-info-hover text-info-foreground"
+              >
+                Go to Dashboard
+              </Button>
+              <Button
+                onClick={() => router.push('/subscription')}
+                variant="outline"
+                size="lg"
+              >
+                Manage Subscription
+              </Button>
+            </div>
+          </div>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
PR 4 of 4 in the payment production-readiness stack (parent: the reconciliation PR). Retarget after the parent squash-merges.

> Replaces #69, which GitHub auto-marked as merged during a botched restack force-push (its head briefly pointed at its base). Same content, same branch.

## Problem
The success page declared 'Subscription Successful!' unconditionally with no polling — a paying user could bounce back to the pricing page and double-subscribe. Error handling flattened every failure into a generic toast (breaking 401 retry-skip and plan-limit details), and the Stripe customer portal was unreachable (no card updates, no failed-payment recovery).

## Changes
- Typed `ApiError` (RFC 7807 parsing) from both fetch helpers; 401s aren't retried; plan-limit/subscription-required errors surface the server's detail
- Checkout: single POST with `{ planId: null, clientRequestId }`, no mutation retries, checkoutUrl guard — no duplicate sessions, no `/undefined` navigations
- Success page is an honest state machine: reconcile via `checkout/complete` (retried on transient failure), 2s→10s polling, neutral states for unverified sessions and direct visits — it never claims a payment happened when one didn't, and never shows the pricing page to someone who just paid
- Manage view: real plan/status/renewal data, cancel-at-period-end messaging ('access until {date}', scheduled banner), 'Manage billing' button → Stripe customer portal; status refetches on mount/focus so portal changes appear immediately
- 36 new Vitest tests incl. a shared no-false-payment-claims assertion

## Testing
118 Vitest tests green, `tsc --noEmit` clean, `nx build web` passes. Review findings addressed in the second and third commits.

